### PR TITLE
findViewById is annotated @Nullable at v23.0.3

### DIFF
--- a/chat_example/src/main/java/io/skygear/chatexample/ConversationActivity.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/ConversationActivity.kt
@@ -64,8 +64,8 @@ class ConversationActivity : AppCompatActivity() {
         val sendBtn = findViewById(R.id.send_btn)
         val attachmentBtn = findViewById(R.id.attachment_btn)
 
-        sendBtn.setOnClickListener { send() }
-        attachmentBtn.setOnClickListener { findAttachment() }
+        sendBtn?.setOnClickListener { send() }
+        attachmentBtn?.setOnClickListener { findAttachment() }
 
         mLoading = ProgressDialog(this)
         mLoading?.setTitle(R.string.loading)


### PR DESCRIPTION
- This behavior is removed at v24.0.0, please refer https://code.google.com/p/android/issues/detail?id=203345

with null check will cause to build fail.