### PR TITLE
Fix message list scroll unexpectedly when update

### DIFF
--- a/chat/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
+++ b/chat/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
@@ -128,6 +128,7 @@ class ConversationFragment : Fragment(),
             this.messagesListViewReachBottomListener = MessagesListViewReachBottomListener(
                     this.messagesListView?.layoutManager as LinearLayoutManager
             )
+            (this.messagesListView?.layoutManager as LinearLayoutManager).isAutoMeasureEnabled = false
             this.messagesListView?.addOnScrollListener(this.messagesListViewReachBottomListener)
         }
 


### PR DESCRIPTION
connects #65 

Set recycler view to disable isAutoMeasureEnabled, workaround for scroll view move unexpectedly when update issue.

`isAutoMeasureEnabled` is used for supporting RecyclerView to measure is size when items changed. And this feature cause the RecycleView scroll unexpectedly when update, and it should be bugs of RecycleView.
In our case, the message list view is match_parent. It is safe for us to disable it