### PR TITLE
Put dokka plugin class path to module gradle for buddybuild and post build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ buildscript {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokka_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+       classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:${dokka_version}"
+    }
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.dokka-android'

--- a/chat_example/buddybuild_postbuild.sh
+++ b/chat_example/buddybuild_postbuild.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo "Uploading apk to HockeyApp..."
+
+if [[ "$BUDDYBUILD_VARIANTS" =~ "release" ]]; then
+  curl \
+    -F "release_type=2" \
+    -F "status=2" \
+    -F "notify=0" \
+    -F "ipa=@$BUDDYBUILD_WORKSPACE/chat_example/build/outputs/apk/chat_example-release.apk" \
+    -H "X-HockeyAppToken: $HOCKEYAPP_APPTOKEN" \
+    https://rink.hockeyapp.net/api/2/apps/$HOCKEYAPP_APPID/app_versions/upload
+  echo "Finished uploading apk to HockeyApp."
+else
+    echo "Only upload release variants to HockeyApp"
+fi


### PR DESCRIPTION
- According to https://github.com/Kotlin/dokka#android, the `classpath` should be placed before applying the plugin. Now buddybuild can successfully build the app.
- buddybuild post build script