### PR TITLE
New title option in ConversationFragment

### DIFF
--- a/chat/src/main/java/io/skygear/plugins/chat/ui/ConversationActivity.kt
+++ b/chat/src/main/java/io/skygear/plugins/chat/ui/ConversationActivity.kt
@@ -12,6 +12,7 @@ class ConversationActivity : AppCompatActivity() {
         @JvmField val ConversationIntentKey = "CONVERSATION"
         @JvmField val LayoutIntentKey = "LAYOUT"
         @JvmField val AvatarAdapterIntentKey = "AVATAR_ADAPTER"
+        @JvmField val TitleOptionIntentKey = "TITLE_OPTION"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -31,7 +32,10 @@ class ConversationActivity : AppCompatActivity() {
                     bundle.putSerializable(ConversationFragment.AvatarAdapterBundleKey,
                             this.intent?.getSerializableExtra(ConversationFragment.AvatarAdapterBundleKey))
                 }
-
+                if (intent?.hasExtra(TitleOptionIntentKey) ?: false) {
+                    bundle.putSerializable(ConversationFragment.TitleOptionBundleKey,
+                            this.intent?.getSerializableExtra(ConversationFragment.TitleOptionBundleKey))
+                }
                 fragment.arguments = bundle
             }
 

--- a/chat/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
+++ b/chat/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
@@ -52,6 +52,7 @@ open class ConversationFragment() :
         val ConversationBundleKey = "CONVERSATION"
         val LayoutResIdBundleKey = "LAYOUT"
         val AvatarAdapterBundleKey = "AVATAR_ADAPTER"
+        val TitleOptionBundleKey = "TITLE_OPTION"
         private val TAG = "ConversationFragment"
         private val MESSAGE_SUBSCRIPTION_MAX_RETRY = 10
         private val REQUEST_PICK_IMAGES = 5001
@@ -83,6 +84,8 @@ open class ConversationFragment() :
     protected var layoutResID: Int = -1
     protected var customAvatarAdapter: AvatarAdapter? = null
 
+    protected var titleOption: ConversationTitleOption? = null
+
     @Override
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -93,6 +96,11 @@ open class ConversationFragment() :
         arguments.getSerializable(AvatarAdapterBundleKey)?.let { adapter ->
             customAvatarAdapter = adapter as AvatarAdapter
         }
+
+        arguments.getSerializable(TitleOptionBundleKey)?.let { option ->
+            titleOption = option as ConversationTitleOption
+        }
+
     }
 
     override fun onAttach(context: Context?) {
@@ -180,9 +188,12 @@ open class ConversationFragment() :
             container: ViewGroup?,
             savedInstanceState: Bundle?
     ): View? {
-        this.activity.title = this.conversation?.title
+
 
         val view = createConversationView(inflater, container)
+        if (titleOption  == ConversationTitleOption.DEFAULT) {
+            this.activity.title = this.conversation?.title
+        }
         // TODO: setup typing indicator subscription
 
         this.takePhotoPermissionManager = createPhotoPermissionManager(this.activity)
@@ -225,7 +236,12 @@ open class ConversationFragment() :
                 }
 
                 override fun onQuerySuccess(records: Array<out Record>?) {
-                    records?.let { conversationView()?.updateAuthors(it.toList()) }
+                    records?.let {
+                        conversationView()?.updateAuthors(records.toList())
+                        if (titleOption  == ConversationTitleOption.OTHER_PARTICIPANTS) {
+                            this@ConversationFragment.activity.title = conversationView()?.getOtherParticipantsTitle()
+                        }
+                    }
                 }
             })
         }

--- a/chat/src/main/java/io/skygear/plugins/chat/ui/ConversationTitleOption.kt
+++ b/chat/src/main/java/io/skygear/plugins/chat/ui/ConversationTitleOption.kt
@@ -1,0 +1,5 @@
+package io.skygear.plugins.chat.ui
+
+enum class ConversationTitleOption {
+    DEFAULT, OTHER_PARTICIPANTS
+}

--- a/chat/src/main/java/io/skygear/plugins/chat/ui/ConversationView.kt
+++ b/chat/src/main/java/io/skygear/plugins/chat/ui/ConversationView.kt
@@ -342,6 +342,17 @@ open class ConversationView: RelativeLayout{
         this.messageListAdapter?.updateMessagesAuthor(userMap)
     }
 
+    open fun getOtherParticipantsTitle(): String {
+        val names = userMap.values.filter {
+            it.chatUserId != this.skygear?.auth?.currentUser?.id
+        }.map {
+            val key = it.displayNameField
+            it.chatUser?.record?.get(key) ?: it.chatUser?.record?.get(User.DefaultUsernameField)
+        }
+        return names?.joinToString(", ")
+
+    }
+
     class ContentTypeChecker : MessageHolders.ContentChecker<Message> {
         companion object {
             val VoiceMessageType: Byte = 1


### PR DESCRIPTION
Title in ConversationFragment can be configured by title option from bundle

- DEFAULT: title from Conversation Record
- OTHER_PARTICIPANTS: title via joining other’s participants’ display names. If display name field is not available, default “username” field is used.

Connects #102