### PR TITLE
Introduce message operation cache objects

### DIFF
--- a/chat/src/androidTest/java/io/skygear/plugins/chat/CacheControllerTest.java
+++ b/chat/src/androidTest/java/io/skygear/plugins/chat/CacheControllerTest.java
@@ -51,7 +51,7 @@ import static io.skygear.plugins.chat.MessageSubscriptionCallback.EVENT_TYPE_DEL
 import static io.skygear.plugins.chat.MessageSubscriptionCallback.EVENT_TYPE_UPDATE;
 
 @RunWith(AndroidJUnit4.class)
-public class ChatControllerTest {
+public class CacheControllerTest {
     static Context context;
     static DateTimeFormatter formatterWithMS;
     CacheController cacheController;

--- a/chat/src/main/java/io/skygear/plugins/chat/CacheController.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/CacheController.java
@@ -163,33 +163,6 @@ class CacheController {
         }
     }
 
-    void getUnsentMessages(final Conversation conversation, final GetCallback<List<Message>> callback) {
-        RealmStore.QueryBuilder<MessageCacheObject> queryBuilder = new RealmStore.QueryBuilder<MessageCacheObject>() {
-            @Override
-            public RealmQuery<MessageCacheObject> buildQueryFrom(RealmQuery<MessageCacheObject> baseQuery) {
-                RealmQuery<MessageCacheObject> query = baseQuery
-                        .equalTo(KEY_CONVERSATION_ID, conversation.getId())
-                        .isNotNull(KEY_SEND_DATE)
-                        .beginGroup()
-                            .equalTo(KEY_ALREADY_SYNC_TO_SERVER, false)
-                            .or()
-                            .equalTo(KEY_FAIL, true)
-                        .endGroup();
-
-                return query;
-            }
-        };
-
-        if (callback != null) {
-            this.store.getMessages(queryBuilder, -1, "creationDate", new RealmStore.ResultCallback<Message[]>() {
-                @Override
-                public void onResultGet(Message[] messages) {
-                    callback.onSuccess(Arrays.asList(messages));
-                }
-            });
-        }
-    }
-
     //endregion
 
     //region Message Operation

--- a/chat/src/main/java/io/skygear/plugins/chat/CacheController.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/CacheController.java
@@ -62,6 +62,15 @@ class CacheController {
         this.store = store;
     }
 
+    void cleanUpOnLaunch() {
+        // Mark pending message operations as failed.
+        //
+        // Message operations that is pending will not progress to failed/success
+        // state because the app is just launched. Therefore we need to move them
+        // to failed state so that the in the clean up.
+        this.markPendingMessageOperationsAsFailed();
+    }
+
     //region Message
 
     void getMessages(@NonNull final Conversation conversation,

--- a/chat/src/main/java/io/skygear/plugins/chat/ChatContainer.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/ChatContainer.java
@@ -86,6 +86,9 @@ public final class ChatContainer {
         }
 
         Realm.init(container.getContext());
+        // Since we are initiating Realm, we make use of this opportunity to clean
+        // up the cache.
+        cacheController.cleanUpOnLaunch();
         this.cacheController = cacheController;
     }
 

--- a/chat/src/main/java/io/skygear/plugins/chat/ChatContainer.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/ChatContainer.java
@@ -674,8 +674,6 @@ public final class ChatContainer {
                             JSONObject object = results.getJSONObject(i);
                             Record record = Record.fromJson(object);
                             Message message = new Message(record);
-                            message.alreadySyncToServer = true;
-                            message.fail = false;
                             messages.add(message);
                         } catch (JSONException e) {
                             Log.e(TAG, "Fail to get message: " + e.getMessage());
@@ -926,7 +924,7 @@ public final class ChatContainer {
             @Override
             public void onSuccess(@Nullable Message savedMessage) {
                 if (savedMessage != null) {
-                    ChatContainer.this.cacheController.didSaveMessage(savedMessage, null);
+                    ChatContainer.this.cacheController.didSaveMessage(savedMessage);
                     ChatContainer.this.cacheController.didCompleteMessageOperation(operation);
                 }
 

--- a/chat/src/main/java/io/skygear/plugins/chat/ErrorSerializer.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/ErrorSerializer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Oursky Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.skygear.plugins.chat;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import io.skygear.skygear.Error;
+
+/**
+ * The Skygear Error Serializer.
+ * <p>
+ * This class converts between error object and JSON object in Skygear defined format.
+ */
+public class ErrorSerializer {
+
+    /**
+     * Serializes an error object
+     *
+     * @param errorObject the error object
+     * @return the json object
+     */
+    public static JSONObject serialize(Error errorObject) {
+        try {
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put("message", errorObject.getDetailMessage());
+            jsonObject.put("code", errorObject.getCodeValue());
+            jsonObject.put("name", errorObject.getName());
+
+            JSONObject infoObject = errorObject.getInfo();
+            if (infoObject != null) {
+                jsonObject.put("info", infoObject);
+            }
+
+            return jsonObject;
+        } catch (JSONException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Deserialize an error from JSON object.
+     *
+     * @param jsonObject the JSON object
+     * @return the error object
+     * @throws JSONException the json exception
+     */
+    public static Error deserialize(JSONObject jsonObject) throws JSONException {
+        String errorString = jsonObject.optString("message");
+        int errorCodeValue = jsonObject.getInt("code");
+        String errorName = jsonObject.optString("name");
+        JSONObject errorInfo = jsonObject.optJSONObject("info");
+
+        return new Error(errorCodeValue, errorName, errorString, errorInfo);
+    }
+}

--- a/chat/src/main/java/io/skygear/plugins/chat/Message.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/Message.java
@@ -31,8 +31,6 @@ public class Message {
      * Transient fields that are not saved to the server
      */
     Date sendDate;
-    boolean alreadySyncToServer;
-    boolean fail;
 
     /**
      * Instantiates a new Message with new Skygear Record.
@@ -179,24 +177,6 @@ public class Message {
      */
     public Date getSendDate() {
         return this.sendDate;
-    }
-
-    /**
-     * Gets if message already sync to server.
-     *
-     * @return if message already sync to server
-     */
-    public boolean isAlreadySyncToServer() {
-        return this.alreadySyncToServer;
-    }
-
-    /**
-     * Gets if failed to message sync to server.
-     *
-     * @return if failed to message sync to server
-     */
-    public boolean isFail() {
-        return this.fail;
     }
 
     /**

--- a/chat/src/main/java/io/skygear/plugins/chat/MessageCacheObject.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/MessageCacheObject.java
@@ -40,8 +40,6 @@ public class MessageCacheObject extends RealmObject {
     static String KEY_EDITION_DATE = "editionDate";
     static String KEY_SEND_DATE = "sendDate";
     static String KEY_DELETED = "deleted";
-    static String KEY_ALREADY_SYNC_TO_SERVER = "alreadySyncToServer";
-    static String KEY_FAIL = "fail";
     static String KEY_JSON_DATA = "jsonData";
 
     @PrimaryKey
@@ -56,10 +54,6 @@ public class MessageCacheObject extends RealmObject {
     Date sendDate;
 
     boolean deleted;
-
-    boolean alreadySyncToServer;
-
-    boolean fail;
 
     String jsonData;
 
@@ -76,8 +70,6 @@ public class MessageCacheObject extends RealmObject {
         this.deleted = deleted == null ? false : deleted;
         this.jsonData = message.toJson().toString();
         this.sendDate = message.sendDate;
-        this.alreadySyncToServer = message.alreadySyncToServer;
-        this.fail = message.fail;
 
         // creationDate of the record originally represents the message creation date on server
         // this overloads the meaning of creationDate, to also represents local creation date.
@@ -95,8 +87,6 @@ public class MessageCacheObject extends RealmObject {
         Record record = Record.fromJson(json);
         Message message = new Message(record);
         message.sendDate = this.sendDate;
-        message.alreadySyncToServer = this.alreadySyncToServer;
-        message.fail = this.fail;
         return message;
     }
 }

--- a/chat/src/main/java/io/skygear/plugins/chat/MessageOperation.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/MessageOperation.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2017 Oursky Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.skygear.plugins.chat;
+
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Date;
+import java.util.UUID;
+
+import io.skygear.skygear.Asset;
+import io.skygear.skygear.Record;
+import io.skygear.skygear.Reference;
+import io.skygear.skygear.Error;
+
+/**
+ * The Message Operation model for Chat Plugin.
+ */
+public class MessageOperation {
+    final Message message;
+
+    /**
+     * The operation identifier.
+     */
+    String operationId;
+
+    /**
+     * The conversation identifier.
+     */
+    String conversationId;
+
+    /**
+     * The message operation type.
+     */
+    Type type;
+
+    /**
+     * The message operation status.
+     */
+    Status status;
+
+    /**
+     * The error related to this operation if the operation has failed.
+     */
+    Error error;
+
+    /**
+     * Transient fields that are not saved to the server
+     */
+    Date sendDate;
+
+    /**
+     * Instantiates a new Message Operation.
+     */
+    public MessageOperation(@NonNull String operationId,
+                            @NonNull Message message,
+                            @NonNull String conversationId,
+                            @NonNull Type type,
+                            @NonNull Status status,
+                            @NonNull Date sendDate,
+                            @Nullable Error error) {
+        this.operationId = operationId;
+        this.message = message;
+        this.conversationId = conversationId;
+        this.type = type;
+        this.status = status;
+        this.sendDate = sendDate;
+        this.error = error;
+    }
+
+    /**
+     * Instantiates a new Message Operation for a pending message.
+     */
+    public MessageOperation(@NonNull Message message,
+                            @NonNull String conversationId,
+                            @NonNull Type type) {
+        this.operationId = UUID.randomUUID().toString();
+        this.message = message;
+        this.conversationId = conversationId;
+        this.type = type;
+        this.status = Status.PENDING;
+        this.sendDate = new Date();
+        this.error = null;
+    }
+
+    /**
+     * Gets id.
+     *
+     * @return the id
+     */
+    @NonNull
+    public String getId() {
+        return this.operationId;
+    }
+
+    /**
+     * Gets conversation id.
+     *
+     * @return the conversation id
+     */
+    @NonNull
+    public String getConversationId() {
+        return this.conversationId;
+    }
+
+
+    /**
+     * Gets status.
+     *
+     * @return the status
+     */
+    @Nullable
+    public Status getStatus() {
+        return this.status;
+    }
+
+    /**
+     * Sets status.
+     *
+     * @param status the status
+     */
+    @Nullable
+    protected void setStatus(Status status) {
+        this.status = status;
+    }
+
+    /**
+     * Gets type.
+     *
+     * @return the type
+     */
+    @Nullable
+    public Type getType() {
+        return this.type;
+    }
+
+    /**
+     * Sets type.
+     *
+     * @param type the type
+     */
+    @Nullable
+    protected void setType(Type type) {
+        this.type = type;
+    }
+
+    /**
+     * Gets message send date.
+     *
+     * @return message send date
+     */
+    public Date getSendDate() {
+        return this.sendDate;
+    }
+
+    /**
+     * Gets message.
+     *
+     * @return the message
+     */
+    public Message getMessage() {
+        return this.message;
+    }
+
+    /**
+     * Gets error.
+     *
+     * @return the error
+     */
+    public Error getError() {
+        return this.error;
+    }
+
+    /**
+     * The Message Operation Status.
+     */
+    public enum Status {
+        PENDING("pending"),
+        FAILED("failed"),
+        SUCCESS("success");
+
+        private final String name;
+
+        /**
+         * Gets name.
+         *
+         * @return the name
+         */
+        public String getName() {
+            return name;
+        }
+
+        Status(String name) {
+            this.name = name;
+        }
+
+        /**
+         * Creates a status from a name
+         *
+         * @param name the name
+         * @return the status
+         */
+        @Nullable
+        static Status fromName(String name) {
+            Status status = null;
+            for (Status eachStatus : Status.values()) {
+                if (eachStatus.getName().equals(name)) {
+                    status = eachStatus;
+                    break;
+                }
+            }
+            return status;
+        }
+    }
+
+    /**
+     * The Message Operation Type.
+     */
+    public enum Type {
+        ADD("add"),
+        EDIT("edit"),
+        DELETE("delete");
+
+        private final String name;
+
+        /**
+         * Gets name.
+         *
+         * @return the name
+         */
+        public String getName() {
+            return name;
+        }
+
+        Type(String name) {
+            this.name = name;
+        }
+
+        /**
+         * Creates a type from a name
+         *
+         * @param name the name
+         * @return the type
+         */
+        @Nullable
+        static Type fromName(String name) {
+            Type type = null;
+            for (Type eachType : Type.values()) {
+                if (eachType.getName().equals(name)) {
+                    type = eachType;
+                    break;
+                }
+            }
+            return type;
+        }
+    }
+}

--- a/chat/src/main/java/io/skygear/plugins/chat/MessageOperationCacheObject.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/MessageOperationCacheObject.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Oursky Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.skygear.plugins.chat;
+
+import android.support.annotation.NonNull;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Date;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.skygear.plugins.chat.Message;
+import io.skygear.skygear.Record;
+import io.skygear.skygear.Error;
+
+/**
+ * The Realm model of Skygear message.
+ */
+public class MessageOperationCacheObject extends RealmObject {
+
+    static String KEY_OPERATION_ID = "operationID";
+    static String KEY_MESSAGE_ID = "messageID";
+    static String KEY_CONVERSATION_ID = "conversationID";
+    static String KEY_TYPE = "type";
+    static String KEY_STATUS = "status";
+    static String KEY_SEND_DATE = "sendDate";
+    static String KEY_JSON_DATA = "jsonData";
+    static String KEY_ERROR_DATA = "errorData";
+
+    @PrimaryKey
+    String operationID;
+
+    String messageID;
+
+    String conversationID;
+
+    String type;
+
+    String status;
+
+    Date sendDate;
+
+    String jsonData;
+
+    String errorData;
+
+
+    public MessageOperationCacheObject() {
+        // for realm
+    }
+
+    public MessageOperationCacheObject(MessageOperation operation) {
+        this.operationID = operation.getId();
+        this.messageID = operation.getMessage().getId();
+        this.conversationID = operation.getConversationId();
+        this.type = operation.getType().getName();
+        this.status = operation.getStatus().getName();
+        this.sendDate = operation.getSendDate();
+        this.jsonData = operation.getMessage().toJson().toString();
+        Error operationError = operation.getError();
+        if (operationError != null) {
+            this.errorData = ErrorSerializer.serialize(operationError).toString();
+        }
+    }
+
+    MessageOperation toMessageOperation() throws Exception {
+        Message message = Message.fromJson(new JSONObject(this.jsonData));
+
+        Error error = null;
+        if (this.errorData != null) {
+            error = ErrorSerializer.deserialize(new JSONObject(this.errorData));
+        }
+        return new MessageOperation(this.operationID,
+                                    message,
+                                    this.conversationID,
+                                    MessageOperation.Type.fromName(this.type),
+                                    MessageOperation.Status.fromName(this.status),
+                                    this.sendDate,
+                                    error);
+    }
+}

--- a/chat/src/main/java/io/skygear/plugins/chat/MessageOperationCallback.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/MessageOperationCallback.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Oursky Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.skygear.plugins.chat;
+
+import io.skygear.skygear.Error;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import javax.annotation.Nonnull;
+
+/**
+ * The callback interface for an message operation
+ */
+public interface MessageOperationCallback {
+    /**
+     * Success callback
+     *
+     * @param operation the message operation
+     * @param message the message
+     */
+    void onSuccess(@NonNull MessageOperation operation, @NonNull Message message);
+
+    /**
+     * Fail callback
+     *
+     * @param error the fail reason
+     */
+    void onFail(@NonNull Error error);
+}

--- a/chat_ui/src/main/kotlin/io.skygear.plugins.chat.ui/ConversationView.kt
+++ b/chat_ui/src/main/kotlin/io.skygear.plugins.chat.ui/ConversationView.kt
@@ -28,6 +28,7 @@ import io.skygear.chatkit.messages.VoiceMessageOnClickListener
 import io.skygear.chatkit.messages.MessageHolders
 import io.skygear.chatkit.messages.MessagesList
 import io.skygear.chatkit.messages.MessagesListAdapter
+import io.skygear.skygear.Error
 import io.skygear.skygear.Record
 
 
@@ -86,6 +87,7 @@ enum class AvatarType(val value: Int) {
 
 open class ConversationView: RelativeLayout{
     private var messagesListView: MessagesList? = null
+    private var messageErrorByIDs: MutableMap<String, Error> = mutableMapOf()
     private var addAttachmentButton: ImageButton? = null
     private var messageSendButton: ImageButton? = null
     private var messageEditText: EditText? = null
@@ -296,8 +298,17 @@ open class ConversationView: RelativeLayout{
         this.voiceButtonHolder?.cancel()
     }
 
-    open fun updateMessage(message: ChatMessage) {
-        this.messageListAdapter?.update(MessagesFromChatMessages(listOf(message)).first())
+    open fun updateMessages(chatMessages: List<ChatMessage>) {
+        for (message: Message in MessagesFromChatMessages(chatMessages)) {
+            this.messageListAdapter?.update(message)
+        }
+    }
+
+    open fun updateMessages(chatMessages: List<ChatMessage>, error: Error) {
+        for (message: Message in MessagesFromChatMessages(chatMessages)) {
+            message.error = error
+            this.messageListAdapter?.update(message)
+        }
     }
 
     open fun updateVoiceMessage(voiceMessage: VoiceMessage) {
@@ -305,8 +316,16 @@ open class ConversationView: RelativeLayout{
         this.messageListAdapter?.update(voiceMessage)
     }
 
-    open fun mergeMessagesToList(messages: List<ChatMessage>) {
-        this.messageListAdapter?.merge(MessagesFromChatMessages(messages))
+    open fun mergeMessages(chatMessages: List<ChatMessage>) {
+        this.messageListAdapter?.merge(MessagesFromChatMessages(chatMessages))
+    }
+
+    open fun mergeMessages(chatMessages: List<ChatMessage>, error: Error) {
+        var messages = MessagesFromChatMessages(chatMessages)
+        for (message: Message in messages) {
+            message.error = error
+        }
+        this.messageListAdapter?.merge(messages)
     }
 
     open fun addMessageToBottom(message: ChatMessage, imageUri: Uri? = null) {
@@ -341,10 +360,25 @@ open class ConversationView: RelativeLayout{
         return multitypeMessages
     }
 
+    fun MessagesFromChatMessages(chatMessages: List<ChatMessage>, error: Error): List<Message> {
+        val multitypeMessages = chatMessages.map {
+            MessageFactory.getMessage(it, getMessageStyle())
+        }
+        multitypeMessages.forEach {
+            updateMessageAuthor(it)
+            updateMessageError(it, error)
+        }
+        return multitypeMessages
+    }
+
     fun MessageFromChatMessage(chatMessage: ChatMessage, uri: Uri?): Message {
         val multitypeMessage = MessageFactory.getMessage(chatMessage, getMessageStyle(), uri)
         updateMessageAuthor(multitypeMessage)
         return multitypeMessage
+    }
+
+    fun updateMessageError(message: Message, error: Error) {
+        message.error = error
     }
 
     fun updateMessageAuthor(message: Message) {

--- a/chat_ui/src/main/kotlin/io.skygear.plugins.chat.ui/model/Message.kt
+++ b/chat_ui/src/main/kotlin/io.skygear.plugins.chat.ui/model/Message.kt
@@ -4,12 +4,14 @@ import io.skygear.chatkit.commons.models.IMessage
 import io.skygear.plugins.chat.Message.Status
 import java.util.*
 import io.skygear.plugins.chat.Message as ChatMessage
+import io.skygear.skygear.Error
 
 open class Message: IMessage {
     val chatMessage: ChatMessage
     var author: User? = null
     var style: MessageStyle
     var statusText: MessageStatusText
+    var error: Error? = null
 
     constructor(m: ChatMessage, style: MessageStyle) {
         this.chatMessage = m
@@ -26,7 +28,7 @@ open class Message: IMessage {
     override fun getText(): String? = this.chatMessage.body
 
     fun getStatus(): String {
-        if (this.chatMessage.isFail) {
+        if (this.error != null) {
             return "Failed"
         }
 


### PR DESCRIPTION
The message operation cache objects is used by chat extension to persist
pending or failed operations. Successful message operations are automatically
removed from persistence store. It is possible for the user of the API
to retry failed message operations or cancel them.

The previous design had a problem that causes failed messages to appear
in the message cache. This implementation only changes the message cache
when the message operations are completed successfully.

**Note**: It is recommended to review this pull request by looking
at the commits (and messages) sequentially.

connects #130
connects #131
connects #132
connects #133