### PR TITLE
Fix admin participant list

### DIFF
--- a/chat_example/src/main/java/io/skygear/chatexample/ConversationsActivity.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/ConversationsActivity.kt
@@ -13,6 +13,7 @@ import android.view.MenuItem
 import android.widget.Toast
 import io.skygear.plugins.chat.* // ktlint-disable no-wildcard-imports
 import io.skygear.plugins.chat.ui.* // ktlint-disable no-wildcard-imports
+import io.skygear.plugins.chat.ui.model.User
 import io.skygear.skygear.Container
 import io.skygear.skygear.Error
 import io.skygear.skygear.LambdaResponseHandler
@@ -109,7 +110,6 @@ class ConversationsActivity : AppCompatActivity() {
         mSkygear.auth.logout(object : LogoutResponseHandler() {
             override fun onLogoutSuccess() {
                 loading.dismiss()
-
                 logoutSuccess()
             }
 
@@ -274,6 +274,7 @@ class ConversationsActivity : AppCompatActivity() {
 
     fun updateAdmins(c: Conversation) {
         val f = UserIdsFragment.newInstance(getString(R.string.add_remove_admins), c.adminIds)
+        f.setConversation(c)
         f.setOnOkBtnClickedListener { ids ->
             mChatContainer.addConversationAdmins(c, ids, object : SaveCallback<Conversation> {
                 override fun onSuccess(new: Conversation?) {

--- a/chat_example/src/main/java/io/skygear/chatexample/ConversationsActivity.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/ConversationsActivity.kt
@@ -276,9 +276,32 @@ class ConversationsActivity : AppCompatActivity() {
         val f = UserIdsFragment.newInstance(getString(R.string.add_remove_admins), c.adminIds)
         f.setConversation(c)
         f.setOnOkBtnClickedListener { ids ->
-            mChatContainer.addConversationAdmins(c, ids, object : SaveCallback<Conversation> {
+
+            Toast.makeText(applicationContext, "Updating admins...", Toast.LENGTH_SHORT).show()
+
+            val idsToRemove = c.adminIds?.toMutableList()
+            idsToRemove?.removeAll(ids.toList())
+
+            mChatContainer.removeConversationAdmins(c, idsToRemove!!, object : SaveCallback<Conversation> {
                 override fun onSuccess(new: Conversation?) {
-                    mAdapter.updateConversation(c, new)
+
+                    mChatContainer.addConversationAdmins(c, ids, object : SaveCallback<Conversation> {
+                        override fun onSuccess(new: Conversation?) {
+                            mChatContainer.getConversation(new?.id!! , object: GetCallback<Conversation> {
+                                override fun onSuccess(`newWithParticipantIds`: Conversation?) {
+                                    mAdapter.updateConversation(c, newWithParticipantIds)
+                                    Toast.makeText(applicationContext, "Admins updated.", Toast.LENGTH_SHORT).show()
+                                }
+
+                                override fun onFail(error: Error) {
+                                }
+                            })
+
+                        }
+
+                        override fun onFail(error: Error) {
+                        }
+                    })
                 }
 
                 override fun onFail(error: Error) {

--- a/chat_example/src/main/java/io/skygear/chatexample/ConversationsActivity.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/ConversationsActivity.kt
@@ -208,6 +208,8 @@ class ConversationsActivity : AppCompatActivity() {
         mChatContainer.setConversationTitle(c, t, object : SaveCallback<Conversation> {
             override fun onSuccess(new: Conversation?) {
                 mAdapter.updateConversation(c, new)
+                Toast.makeText(applicationContext, "Title updated.", Toast.LENGTH_SHORT).show()
+
             }
 
             override fun onFail(error: Error) {
@@ -267,6 +269,7 @@ class ConversationsActivity : AppCompatActivity() {
 
             override fun onSuccess(result: Boolean?) {
                 Log.i(LOG_TAG, "Successfully delete the conversation")
+                Toast.makeText(applicationContext, "Conversation deleted.", Toast.LENGTH_SHORT).show()
                 getAllConversations()
             }
         })

--- a/chat_example/src/main/java/io/skygear/chatexample/ConversationsAdapter.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/ConversationsAdapter.kt
@@ -11,9 +11,9 @@ class ConversationsAdapter : RecyclerView.Adapter<ConversationsAdapter.ViewHolde
     private val LOG_TAG = "Adapter"
 
     private var mConversations: List<Conversation> = listOf()
-    private var mListener: (Conversation) -> Unit = {}
+    private var mListener: (Int) -> Unit = {}
 
-    fun setOnClickListener(listener: (Conversation) -> Unit) {
+    fun setOnClickListener(listener: (Int) -> Unit) {
         mListener = listener
     }
 
@@ -22,13 +22,17 @@ class ConversationsAdapter : RecyclerView.Adapter<ConversationsAdapter.ViewHolde
         notifyDataSetChanged()
     }
 
+    fun getConversation(pos: Int) : Conversation {
+        return mConversations[pos]
+    }
+
     fun updateConversation(old: Conversation, new: Conversation?) {
         if (new != null) {
             val conversations: MutableList<Conversation> = mConversations.toMutableList()
             val idx = conversations.indexOf(old)
-
             if (idx != -1) {
                 conversations[idx] = new
+                mConversations = conversations.toList();
                 notifyDataSetChanged()
             }
         }
@@ -57,10 +61,8 @@ class ConversationsAdapter : RecyclerView.Adapter<ConversationsAdapter.ViewHolde
         holder.lastMsgTv.text = conversation?.lastReadMessage?.body
 
         with(holder.container) {
-            tag = conversation
             setOnClickListener { v ->
-                val uc = v.tag as Conversation
-                mListener(uc)
+                mListener(position)
             }
         }
     }

--- a/chat_example/src/main/java/io/skygear/chatexample/CreateConversationActivity.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/CreateConversationActivity.kt
@@ -86,7 +86,7 @@ class CreateConversationActivity : AppCompatActivity() {
             loading.show()
 
             mChatContainer.createConversation(participantIds, title, null, null, object : SaveCallback<Conversation> {
-                override fun onSuccess(`object`: Conversation?) {
+                override fun onSuccess(con: Conversation?) {
                     loading.dismiss()
                     toast("Conversation created!")
                     finish()

--- a/chat_example/src/main/java/io/skygear/chatexample/UserIdsFragment.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/UserIdsFragment.kt
@@ -13,6 +13,7 @@ import android.widget.Button
 import android.widget.TextView
 import io.skygear.plugins.chat.ChatContainer
 import io.skygear.plugins.chat.ChatUser
+import io.skygear.plugins.chat.Conversation
 import io.skygear.plugins.chat.GetCallback
 import io.skygear.skygear.Container
 import io.skygear.skygear.Error
@@ -23,7 +24,7 @@ class UserIdsFragment : DialogFragment() {
 
     private val mSkygear: Container
     private val mChatContainer: ChatContainer
-
+    private var mConversation: Conversation? = null
     private var mAdapter: UserIdsAdapter? = null
     private var mUserIdsRv: RecyclerView? = null
 
@@ -81,14 +82,29 @@ class UserIdsFragment : DialogFragment() {
 
         super.onResume()
 
+
         mChatContainer.getChatUsers(object : GetCallback<List<ChatUser>> {
             override fun onSuccess(list: List<ChatUser>?) {
-                mAdapter?.setUserIds(list, arguments.getStringArrayList(SELECT_IDS_KEY))
-            }
+                if (mConversation != null) {
+                    var allUserList = list?.toMutableList()
 
+                    // Only display Participants here if a conversation is specified
+                    // Remove those not contained in participant IDs
+                    allUserList?.removeAll {
+                        !mConversation?.participantIds?.contains(it.id)!!
+                    }
+                    mAdapter?.setUserIds(allUserList, arguments.getStringArrayList(SELECT_IDS_KEY))
+                } else {
+                    mAdapter?.setUserIds(list, arguments.getStringArrayList(SELECT_IDS_KEY))
+                }
+            }
             override fun onFail(error: Error) {
             }
         })
+    }
+
+    fun setConversation(conversation: Conversation) {
+        mConversation = conversation
     }
 
     fun setOnOkBtnClickedListener(listener: (List<String>) -> Unit) {


### PR DESCRIPTION
Addressing these issues:

1. *Refresh button/auto refresh*: when I am managing participants, admins and name, as changes isn't reflected in real-time, it is kinda confusing.
2. *Alert*: for each of the actions, possible to add an alert box to indicate that the action is completed?
3. *Add/Remove admin*: it is possible to load only the participants of the conversation? 