### PR TITLE
Voice message bug fix

### DIFF
--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
@@ -215,6 +215,11 @@ open class ConversationFragment() :
         return view
     }
 
+    override fun onStop() {
+        super.onStop()
+        this.voicePlayer?.stop()
+    }
+
     override fun onResume() {
         super.onResume()
         if (conversationView()?.itemCount() == 0) {
@@ -521,17 +526,19 @@ open class ConversationFragment() :
     }
 
     override fun onVoiceMessageClick(voiceMessage: VoiceMessage) {
-        if (voiceMessage.state == VoiceMessage.State.PLAYING) {
-            this.voicePlayer?.pause()
-            return
+        if (this.voicePlayer?.message == voiceMessage) {
+            when (voiceMessage.state) {
+                VoiceMessage.State.INITIAL, VoiceMessage.State.PAUSED -> this.voicePlayer?.play()
+                VoiceMessage.State.PLAYING -> this.voicePlayer?.pause()
+            }
         }
-
-        if (this.voicePlayer?.message != voiceMessage) {
+        else
+        {
             this.voicePlayer?.stop()
             this.voicePlayer?.message = voiceMessage
+            this.voicePlayer?.play()
         }
 
-        this.voicePlayer?.play()
     }
 
     override fun onVoiceMessageStateChanged(voiceMessage: VoiceMessage) {

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/VoiceMessage.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/VoiceMessage.kt
@@ -57,6 +57,6 @@ open class VoiceMessage : Message, MessageContentType {
     }
 
     enum class State {
-        INITIAL, PLAYING, PAUSED
+        INITIAL, PLAYING, PAUSED, PREPARING
     }
 }

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/utils/VoiceMessagePlayer.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/utils/VoiceMessagePlayer.kt
@@ -33,6 +33,7 @@ class VoiceMessagePlayer(val context: Context) {
             }
 
             this.mediaPlayer?.setOnErrorListener { _, what, _ ->
+                msg.state = VoiceMessage.State.INITIAL
                 this@VoiceMessagePlayer.playerErrorListener?.let { listener ->
                     when (what) {
                         MEDIA_ERROR_SERVER_DIED -> Error(MEDIA_ERROR_SERVER_DIED, "Server Error")
@@ -48,6 +49,7 @@ class VoiceMessagePlayer(val context: Context) {
                 msg.state = VoiceMessage.State.PLAYING
                 this@VoiceMessagePlayer.messageStateChangeListener?.onVoiceMessageStateChanged(msg)
             }
+            msg.state = VoiceMessage.State.PREPARING
             this.mediaPlayer?.prepareAsync()
         }
     }

--- a/chat_ui/src/main/res/layout/conversation_view.xml
+++ b/chat_ui/src/main/res/layout/conversation_view.xml
@@ -77,6 +77,16 @@
                 android:layout_height="wrap_content">
 
                 <TextView
+                    android:id="@+id/voice_recording_seconds"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="50dp"
+                    android:layout_centerVertical="true"
+                    android:layout_alignBottom="@id/voice_recording_btn_holder_hint"
+                    android:textColor="@color/warm_grey"
+                    android:visibility="invisible" />
+
+                <TextView
                     android:id="@+id/voice_recording_btn_holder_hint"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/chat_ui/src/main/res/values/strings.xml
+++ b/chat_ui/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="please_turn_on_write_external_storage_permissions">Please turn on storage permission at [Settings] page</string>
     <string name="please_turn_on_audio_recording_permission">Please turn on audio recording permission at [Settings] page</string>
     <string name="camera_is_not_available">Camera is not available</string>
-
+    <string name="voice_too_short">Hold to record and release to send.</string>
     <string name="close">Close</string>
     <string name="slide_to_cancel">Slide to cancel</string>
     <string name="type_a_message">Type a message...</string>


### PR DESCRIPTION
1.  Update voice recording UI
- Cancel sending voice message if duration is less than 1 second
- Show duration in the bottom bar
2. Voice Message playing Bug Fix
- Stop voice message from playing in onStop()
- Add PREPARING state in VoiceMessage
- voicePlayer not disturbed by click events if it is in PREPARING state

Connects #152 
Connects #158