### PR TITLE
getChatUsers API

### DIFF
--- a/chat/src/androidTest/java/io/skygear/plugins/chat/CacheControllerTest.java
+++ b/chat/src/androidTest/java/io/skygear/plugins/chat/CacheControllerTest.java
@@ -37,8 +37,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import io.realm.Realm;
 import io.realm.RealmResults;
@@ -78,6 +80,12 @@ public class CacheControllerTest {
         }
 
         store.setMessages(messages);
+
+        ArrayList<Participant> users = new ArrayList<>();
+        users.add(new Participant(new Record("user", "user1")));
+        users.add(new Participant(new Record("user", "user2")));
+        users.add(new Participant(new Record("user", "user3")));
+        store.setParticipants(users);
     }
 
     void tearDownFixture() {
@@ -524,4 +532,48 @@ public class CacheControllerTest {
     }
 
     //endregion
+
+    //region Participant
+    @Test
+    public void testGetParticipants() {
+        this.cacheController.getParticipants(new ArrayList<String>() {{
+            add("user2");
+        }}, new GetParticipantsCallback() {
+            @Override
+            public void onGetCachedResult(@Nullable Map<String, Participant> participantsMap) {
+                Assert.assertEquals(1, participantsMap.size());
+                Assert.assertNotNull(participantsMap.get("user2"));
+            }
+
+            @Override
+            public void onSuccess(@Nullable Map<String, Participant> object) {
+
+            }
+
+            @Override
+            public void onFail(@NonNull Error error) {
+
+            }
+        });
+
+        this.cacheController.getParticipants(null, new GetParticipantsCallback() {
+            @Override
+            public void onGetCachedResult(@Nullable Map<String, Participant> participantsMap) {
+                Assert.assertEquals(3, participantsMap.size());
+                Assert.assertNotNull(participantsMap.get("user1"));
+                Assert.assertNotNull(participantsMap.get("user2"));
+                Assert.assertNotNull(participantsMap.get("user3"));
+            }
+
+            @Override
+            public void onSuccess(@Nullable Map<String, Participant> object) {
+
+            }
+
+            @Override
+            public void onFail(@NonNull Error error) {
+
+            }
+        });
+    }
 }

--- a/chat/src/androidTest/java/io/skygear/plugins/chat/CacheControllerTest.java
+++ b/chat/src/androidTest/java/io/skygear/plugins/chat/CacheControllerTest.java
@@ -536,18 +536,13 @@ public class CacheControllerTest {
     //region Participant
     @Test
     public void testGetParticipants() {
-        this.cacheController.getParticipants(new ArrayList<String>() {{
+        this.cacheController.fetchParticipants(new ArrayList<String>() {{
             add("user2");
-        }}, new GetParticipantsCallback() {
+        }}, new GetCallback<Map<String, Participant>>() {
             @Override
-            public void onGetCachedResult(@Nullable Map<String, Participant> participantsMap) {
+            public void onSuccess(@Nullable Map<String, Participant> participantsMap) {
                 Assert.assertEquals(1, participantsMap.size());
                 Assert.assertNotNull(participantsMap.get("user2"));
-            }
-
-            @Override
-            public void onSuccess(@Nullable Map<String, Participant> object) {
-
             }
 
             @Override
@@ -556,18 +551,13 @@ public class CacheControllerTest {
             }
         });
 
-        this.cacheController.getParticipants(null, new GetParticipantsCallback() {
+        this.cacheController.fetchParticipants(null, new GetCallback<Map<String, Participant>>() {
             @Override
-            public void onGetCachedResult(@Nullable Map<String, Participant> participantsMap) {
+            public void onSuccess(@Nullable Map<String, Participant> participantsMap) {
                 Assert.assertEquals(3, participantsMap.size());
                 Assert.assertNotNull(participantsMap.get("user1"));
                 Assert.assertNotNull(participantsMap.get("user2"));
                 Assert.assertNotNull(participantsMap.get("user3"));
-            }
-
-            @Override
-            public void onSuccess(@Nullable Map<String, Participant> object) {
-
             }
 
             @Override

--- a/chat/src/main/java/io/skygear/plugins/chat/CacheController.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/CacheController.java
@@ -22,6 +22,7 @@ import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
@@ -285,5 +286,15 @@ class CacheController {
         this.store.markMessageOperationsAsFailed(queryBuilder, null);
     }
 
+    //endregion
+
+    //region Chat Users
+    void didParticipants(Collection<Participant> participants) {
+        this.store.setParticipants(participants);
+    }
+
+    void getParticipants(Collection<String> participantIds, GetParticipantsCallback callback) {
+        this.store.getParticipantsWithIds(participantIds, callback);
+    }
     //endregion
 }

--- a/chat/src/main/java/io/skygear/plugins/chat/CacheController.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/CacheController.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import io.realm.RealmQuery;
 import io.skygear.skygear.Error;
@@ -289,11 +290,11 @@ class CacheController {
     //endregion
 
     //region Chat Users
-    void didParticipants(Collection<Participant> participants) {
+    void didFetchParticipants(Collection<Participant> participants) {
         this.store.setParticipants(participants);
     }
 
-    void getParticipants(Collection<String> participantIds, GetParticipantsCallback callback) {
+    void fetchParticipants(Collection<String> participantIds, @Nullable GetCallback<Map<String, Participant>> callback) {
         this.store.getParticipantsWithIds(participantIds, callback);
     }
     //endregion

--- a/chat/src/main/java/io/skygear/plugins/chat/ChatContainer.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/ChatContainer.java
@@ -1239,27 +1239,16 @@ public final class ChatContainer {
         }
     }
 
-    /* --- Chat User --- */
-    /**
-     * Gets all users for the chat plugins.
-     *
-     * @param callback the callback
-     */
-    public void getParticipants(@Nullable final GetParticipantsCallback callback) {
-        getParticipants(null, callback);
-    }
-
-
+    /* --- Participants --- */
     /**
      * Gets users for the chat plugins. If participantIds, returns all users.
      * @param participantIds participant ID to be fetched
      * @param callback the callback
      */
-    public void getParticipants(@Nullable Collection<String> participantIds, @Nullable final GetParticipantsCallback callback) {
+    public void getParticipants(@NonNull Collection<String> participantIds, @Nullable final GetParticipantsCallback callback) {
         Query query = new Query("user");
-        if (participantIds != null) {
-           query.contains("_id", new ArrayList(participantIds));
-        }
+        query.contains("_id", new ArrayList(participantIds));
+        query.setLimit(participantIds.size());
         Database publicDB = this.skygear.getPublicDatabase();
         cacheController.getParticipants(participantIds, callback);
 

--- a/chat/src/main/java/io/skygear/plugins/chat/ChatContainer.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/ChatContainer.java
@@ -1250,7 +1250,7 @@ public final class ChatContainer {
         query.contains("_id", new ArrayList(participantIds));
         query.setLimit(participantIds.size());
         Database publicDB = this.skygear.getPublicDatabase();
-        cacheController.getParticipants(participantIds, callback);
+        cacheController.fetchParticipants(participantIds, CreateGetParticipantsCallback(callback));
 
         GetCallback<List<Participant>> publicDBCallback = new GetCallback<List<Participant>>() {
             @Override
@@ -1260,7 +1260,7 @@ public final class ChatContainer {
                 for (Participant user : participants) {
                     map.put(user.getId(), user);
                 }
-                cacheController.didParticipants(participants);
+                cacheController.didFetchParticipants(participants);
                 callback.onSuccess(map);
             }
 
@@ -1281,6 +1281,22 @@ public final class ChatContainer {
                 return participants;
             }
         });
+    }
+
+    private GetCallback<Map<String, Participant>> CreateGetParticipantsCallback(@Nullable  final GetParticipantsCallback callback) {
+        return new GetCallback<Map<String, Participant>>() {
+            @Override
+            public void onSuccess(@Nullable Map<String, Participant> object) {
+                if (callback != null) {
+                    callback.onGetCachedResult(object);
+                }
+            }
+
+            @Override
+            public void onFail(@NonNull Error error) {
+                Log.e(TAG, "Failed to load message from cache: " + error.getMessage());
+            }
+        };
     }
 
     /* --- Subscription--- */

--- a/chat/src/main/java/io/skygear/plugins/chat/GetParticipantsCallback.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/GetParticipantsCallback.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Oursky Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.skygear.plugins.chat;
+
+import android.support.annotation.Nullable;
+
+import java.util.Map;
+
+public interface GetParticipantsCallback extends GetCallback<Map<String, Participant>> {
+    /**
+     * Get cached result.
+     *
+     * @param participantsMap cached participants
+     */
+    void onGetCachedResult(@Nullable Map<String, Participant> participantsMap);
+}

--- a/chat/src/main/java/io/skygear/plugins/chat/Participant.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/Participant.java
@@ -11,7 +11,7 @@ import io.skygear.skygear.Record;
 /**
  * The User model for the Chat Plugin.
  */
-public class ChatUser {
+public class Participant {
     // TODO: Implement RecordWrapper when it is available
 
     private final Record record;
@@ -21,7 +21,7 @@ public class ChatUser {
      *
      * @param record the record
      */
-    ChatUser(final Record record) {
+    Participant(final Record record) {
         this.record = record;
     }
 
@@ -61,7 +61,7 @@ public class ChatUser {
      * @return a chat user
      * @throws JSONException the JSON exception
      */
-    public static ChatUser fromJson(JSONObject jsonObject) throws JSONException {
-        return new ChatUser(Record.fromJson(jsonObject));
+    public static Participant fromJson(JSONObject jsonObject) throws JSONException {
+        return new Participant(Record.fromJson(jsonObject));
     }
 }

--- a/chat/src/main/java/io/skygear/plugins/chat/Participant.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/Participant.java
@@ -21,7 +21,7 @@ public class Participant {
      *
      * @param record the record
      */
-    Participant(final Record record) {
+    public Participant(final Record record) {
         this.record = record;
     }
 

--- a/chat/src/main/java/io/skygear/plugins/chat/ParticipantCacheObject.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/ParticipantCacheObject.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Oursky Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.skygear.plugins.chat;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+import io.skygear.skygear.Record;
+
+/**
+ * The Realm model of Participant.
+ */
+public class ParticipantCacheObject extends RealmObject {
+
+    static String KEY_RECORD_ID = "recordID";
+    static String KEY_JSON_DATA = "jsonData";
+
+    @PrimaryKey
+    String recordID;
+    String jsonData;
+
+    public ParticipantCacheObject() {
+        // for realm
+    }
+
+    public ParticipantCacheObject(Participant user) {
+        this.recordID = user.getId();
+        this.jsonData = user.getRecord().toJson().toString();
+    }
+
+    Participant toParticipant() throws JSONException {
+        JSONObject json = new JSONObject(this.jsonData);
+        Record record = Record.fromJson(json);
+        Participant participant = new Participant(record);
+        return participant;
+    }
+}

--- a/chat/src/main/java/io/skygear/plugins/chat/ParticipantMigration.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/ParticipantMigration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Oursky Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.skygear.plugins.chat;
+
+
+import io.realm.DynamicRealm;
+import io.realm.RealmMigration;
+import io.realm.RealmSchema;
+
+public class ParticipantMigration implements RealmMigration {
+    @Override
+    public void migrate(DynamicRealm realm, long oldVersion, long newVersion) {
+        if (oldVersion == 2) {
+            RealmSchema schema = realm.getSchema();
+            schema.create("ParticipantCacheObject")
+                    .addField(ParticipantCacheObject.KEY_RECORD_ID, String.class)
+                    .addField(ParticipantCacheObject.KEY_JSON_DATA, String.class)
+                    .addPrimaryKey(ParticipantCacheObject.KEY_RECORD_ID);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return 39;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return (o instanceof ParticipantMigration);
+    }
+}

--- a/chat/src/main/java/io/skygear/plugins/chat/RealmStore.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/RealmStore.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -443,7 +444,7 @@ class RealmStore {
     }
 
     void getParticipantsWithIds(@Nonnull final Collection<String> participantIds,
-                                @Nonnull final GetParticipantsCallback callback) {
+                                @Nonnull final GetCallback<Map<String, Participant>> callback) {
         if (callback != null) {
             RealmQuery<ParticipantCacheObject> query = null;
             if (participantIds == null || participantIds.isEmpty()) {
@@ -471,7 +472,7 @@ class RealmStore {
         }
     }
 
-    void getParticipants(RealmResults<ParticipantCacheObject> results, GetParticipantsCallback callback) {
+    void getParticipants(RealmResults<ParticipantCacheObject> results, GetCallback<Map<String, Participant>> callback) {
         HashMap<String, Participant> participantsMap = new HashMap<>();
         for (ParticipantCacheObject object: results) {
             try {
@@ -480,7 +481,7 @@ class RealmStore {
                 Log.e(TAG, "Failed to serialize Chat User, reason: " + e.getMessage());
             }
         }
-        callback.onGetCachedResult(participantsMap);
+        callback.onSuccess(participantsMap);
     }
 
     @RealmModule(library = true, classes = {MessageCacheObject.class, MessageOperationCacheObject.class, ParticipantCacheObject.class})

--- a/chat_example/src/main/java/io/skygear/chatexample/ChatUsesAdapter.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/ChatUsesAdapter.kt
@@ -6,18 +6,18 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import io.skygear.plugins.chat.ChatUser
+import io.skygear.plugins.chat.Participant
 
 class ChatUsesAdapter(currentUserId: String?) : RecyclerView.Adapter<ChatUsesAdapter.ViewHolder>() {
     private val LOG_TAG: String? = "ChatUsesAdapter"
 
-    private var mChatUsers: List<ChatUser> = listOf()
-    private var mSelectedChatUsers: MutableList<ChatUser> = mutableListOf()
+    private var mParticipants: List<Participant> = listOf()
+    private var mSelectedParticipants: MutableList<Participant> = mutableListOf()
     private val mCurrentUserId = currentUserId
 
-    fun setChatUsers(chatUsers: List<ChatUser>?) {
-        if (chatUsers != null) {
-            mChatUsers = chatUsers.filter {
+    fun setParticipants(participants: Map<String, Participant>?) {
+        if (participants != null) {
+            mParticipants = participants.values.filter {
                 it.id != mCurrentUserId
             }
 
@@ -25,8 +25,8 @@ class ChatUsesAdapter(currentUserId: String?) : RecyclerView.Adapter<ChatUsesAda
         }
     }
 
-    fun getSelected(): List<ChatUser> {
-        return mSelectedChatUsers
+    fun getSelected(): List<Participant> {
+        return mSelectedParticipants
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -35,27 +35,27 @@ class ChatUsesAdapter(currentUserId: String?) : RecyclerView.Adapter<ChatUsesAda
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val chatUser: ChatUser = mChatUsers[position]
+        val participant: Participant = mParticipants[position]
 
-        holder.idTv.text = chatUser.id
-        if (!chatUser.record.get("username")?.toString().isNullOrEmpty()) {
-                holder.idTv.text = chatUser.record.get("username").toString()
+        holder.idTv.text = participant.id
+        if (!participant.record.get("username")?.toString().isNullOrEmpty()) {
+                holder.idTv.text = participant.record.get("username").toString()
         }
-        holder.idCb.isChecked = chatUser in mSelectedChatUsers
+        holder.idCb.isChecked = participant in mSelectedParticipants
 
         holder.idCb.setOnClickListener { it: View? ->
             val cb = (it as AppCompatCheckBox)
 
             if(cb.isChecked) {
-                mSelectedChatUsers.add(chatUser)
+                mSelectedParticipants.add(participant)
             } else {
-                mSelectedChatUsers.remove(chatUser)
+                mSelectedParticipants.remove(participant)
             }
         }
     }
 
     override fun getItemCount(): Int {
-        return mChatUsers.size
+        return mParticipants.size
     }
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {

--- a/chat_example/src/main/java/io/skygear/chatexample/CreateConversationActivity.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/CreateConversationActivity.kt
@@ -10,7 +10,6 @@ import android.widget.Toast
 import io.skygear.plugins.chat.* // ktlint-disable no-wildcard-imports
 import io.skygear.skygear.Container
 import io.skygear.skygear.Error
-import java.util.* // ktlint-disable no-wildcard-imports
 
 class CreateConversationActivity : AppCompatActivity() {
     private val LOG_TAG: String? = "CreateConversation"
@@ -53,10 +52,15 @@ class CreateConversationActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
 
-        mChatContainer.getChatUsers(object : GetCallback<List<ChatUser>> {
-            override fun onSuccess(list: List<ChatUser>?) {
-                mAdapter.setChatUsers(list)
+        mChatContainer.getParticipants(object : GetParticipantsCallback {
+            override fun onGetCachedResult(participantsMap: MutableMap<String, Participant>?) {
+                mAdapter.setParticipants(participantsMap)
             }
+
+            override fun onSuccess(participantsMap: MutableMap<String, Participant>?) {
+                mAdapter.setParticipants(participantsMap)
+            }
+
 
             override fun onFail(error: Error) {
             }
@@ -72,7 +76,7 @@ class CreateConversationActivity : AppCompatActivity() {
         f.show(supportFragmentManager, "create_conversation")
     }
 
-    fun createConversation(users: List<ChatUser>?, title: String?) {
+    fun createConversation(users: List<Participant>?, title: String?) {
         if (users != null && users.isNotEmpty()) {
             val participantIds = users.map { it.id }.toMutableSet()
             val currentUser = mSkygear.auth.currentUser

--- a/chat_example/src/main/java/io/skygear/chatexample/CreateConversationActivity.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/CreateConversationActivity.kt
@@ -19,11 +19,13 @@ class CreateConversationActivity : AppCompatActivity() {
     private val mAdapter: ChatUsesAdapter
     private var mCreateBtn: Button? = null
     private var mUserIdsRv: RecyclerView? = null
+    private var mParticipantsFetcher: ParticipantsFetcher? = null
 
     init {
         mSkygear = Container.defaultContainer(this)
         mChatContainer = ChatContainer.getInstance(mSkygear)
         mAdapter = ChatUsesAdapter(mSkygear.auth.currentUser.id)
+        mParticipantsFetcher = ParticipantsFetcher(mSkygear)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -52,7 +54,7 @@ class CreateConversationActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
 
-        mChatContainer.getParticipants(object : GetParticipantsCallback {
+        mParticipantsFetcher?.fetch(object : GetParticipantsCallback {
             override fun onGetCachedResult(participantsMap: MutableMap<String, Participant>?) {
                 mAdapter.setParticipants(participantsMap)
             }

--- a/chat_example/src/main/java/io/skygear/chatexample/ParticipantsFetcher.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/ParticipantsFetcher.kt
@@ -1,0 +1,37 @@
+package io.skygear.chatexample
+
+
+import io.skygear.plugins.chat.GetParticipantsCallback
+import io.skygear.plugins.chat.Participant
+import io.skygear.skygear.*
+import java.util.*
+
+
+open class ParticipantsFetcher {
+    private val container: Container
+    constructor(container: Container) {
+        this.container = container
+    }
+
+    open fun fetch(callback: GetParticipantsCallback) {
+        if (callback != null) {
+            val publicDB = this.container.publicDatabase
+            val query = Query("user")
+            //TODO: unset limit after https://github.com/SkygearIO/skygear-SDK-Android/issues/210 is closed
+            query.limit = 999
+            publicDB.query(query, object : RecordQueryResponseHandler() {
+                override fun onQueryError(error: Error?) {
+                    error?.let {
+                        callback.onFail(error)
+                    }
+                }
+
+                override fun onQuerySuccess(records: Array<out Record>?) {
+                    val participants = records?.map { p -> Participant(p)}?.associateBy({ it.id }, { it })
+                    callback.onSuccess(participants)
+                }
+            })
+        }
+    }
+
+}

--- a/chat_example/src/main/java/io/skygear/chatexample/UserIdsAdapter.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/UserIdsAdapter.kt
@@ -6,17 +6,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import io.skygear.plugins.chat.ChatUser
+import io.skygear.plugins.chat.Participant
 
 class UserIdsAdapter(val currentUserId: String?) : RecyclerView.Adapter<UserIdsAdapter.ViewHolder>() {
     private val LOG_TAG: String? = "UserIdsAdapter"
 
-    private var chatUsers: List<ChatUser> = listOf()
+    private var participants: List<Participant> = listOf()
     private var selectedIds: MutableList<String> = mutableListOf()
 
-    fun setUserIds(chatUsers: List<ChatUser>?, selectedIds: List<String>?) {
-        if (chatUsers != null) {
-            this.chatUsers = chatUsers.filter {
+    fun setUserIds(participants: List<Participant>?, selectedIds: List<String>?) {
+        if (participants != null) {
+            this.participants = participants.filter {
                 it.id != currentUserId
             }
         }
@@ -38,24 +38,24 @@ class UserIdsAdapter(val currentUserId: String?) : RecyclerView.Adapter<UserIdsA
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val chatUser: ChatUser = chatUsers[position]
-        holder.idTv.text = chatUser.record.get("username").toString()
+        val participant: Participant = participants[position]
+        holder.idTv.text = participant.record.get("username").toString()
 
-        holder.idCb.isChecked = chatUser.id in selectedIds
+        holder.idCb.isChecked = participant.id in selectedIds
 
         holder.idCb.setOnClickListener { it: View? ->
             val cb = (it as AppCompatCheckBox)
 
             if(cb.isChecked) {
-                selectedIds.add(chatUser.id)
+                selectedIds.add(participant.id)
             } else {
-                selectedIds.remove(chatUser.id)
+                selectedIds.remove(participant.id)
             }
         }
     }
 
     override fun getItemCount(): Int {
-        return chatUsers.size
+        return participants.size
     }
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {

--- a/chat_example/src/main/java/io/skygear/chatexample/UserIdsFragment.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/UserIdsFragment.kt
@@ -12,9 +12,9 @@ import android.view.WindowManager
 import android.widget.Button
 import android.widget.TextView
 import io.skygear.plugins.chat.ChatContainer
-import io.skygear.plugins.chat.ChatUser
+import io.skygear.plugins.chat.Participant
 import io.skygear.plugins.chat.Conversation
-import io.skygear.plugins.chat.GetCallback
+import io.skygear.plugins.chat.GetParticipantsCallback
 import io.skygear.skygear.Container
 import io.skygear.skygear.Error
 import java.util.* // ktlint-disable no-wildcard-imports
@@ -82,23 +82,27 @@ class UserIdsFragment : DialogFragment() {
 
         super.onResume()
 
+        mChatContainer.getParticipants(object : GetParticipantsCallback {
+            override fun onGetCachedResult(participantsMap: MutableMap<String, Participant>?) {
+                mAdapter?.setUserIds(participantsMap?.values?.toList(), arguments.getStringArrayList(SELECT_IDS_KEY))
+            }
 
-        mChatContainer.getChatUsers(object : GetCallback<List<ChatUser>> {
-            override fun onSuccess(list: List<ChatUser>?) {
+            override fun onFail(error: Error) {
+
+            }
+
+            override fun onSuccess(participantsMap: MutableMap<String, Participant>?) {
                 if (mConversation != null) {
-                    var allUserList = list?.toMutableList()
-
-                    // Only display Participants here if a conversation is specified
+                    var allUserList = participantsMap?.values?.toMutableList()
+                    // Only display Participant here if a conversation is specified
                     // Remove those not contained in participant IDs
                     allUserList?.removeAll {
                         !mConversation?.participantIds?.contains(it.id)!!
                     }
                     mAdapter?.setUserIds(allUserList, arguments.getStringArrayList(SELECT_IDS_KEY))
                 } else {
-                    mAdapter?.setUserIds(list, arguments.getStringArrayList(SELECT_IDS_KEY))
+                    mAdapter?.setUserIds(participantsMap?.values?.toList(), arguments.getStringArrayList(SELECT_IDS_KEY))
                 }
-            }
-            override fun onFail(error: Error) {
             }
         })
     }

--- a/chat_example/src/main/java/io/skygear/chatexample/UserIdsFragment.kt
+++ b/chat_example/src/main/java/io/skygear/chatexample/UserIdsFragment.kt
@@ -27,6 +27,7 @@ class UserIdsFragment : DialogFragment() {
     private var mConversation: Conversation? = null
     private var mAdapter: UserIdsAdapter? = null
     private var mUserIdsRv: RecyclerView? = null
+    private var mParticipantsFetcher: ParticipantsFetcher? = null
 
     companion object {
         private val TITLE_KEY = "title_key"
@@ -46,6 +47,7 @@ class UserIdsFragment : DialogFragment() {
     init {
         mSkygear = Container.defaultContainer(activity)
         mChatContainer = ChatContainer.getInstance(mSkygear)
+        mParticipantsFetcher = ParticipantsFetcher(mSkygear)
     }
 
     override fun onCreateView(inflater: LayoutInflater?,
@@ -82,7 +84,7 @@ class UserIdsFragment : DialogFragment() {
 
         super.onResume()
 
-        mChatContainer.getParticipants(object : GetParticipantsCallback {
+        mParticipantsFetcher?.fetch(object : GetParticipantsCallback {
             override fun onGetCachedResult(participantsMap: MutableMap<String, Participant>?) {
                 mAdapter?.setUserIds(participantsMap?.values?.toList(), arguments.getStringArrayList(SELECT_IDS_KEY))
             }

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
@@ -263,19 +263,16 @@ open class ConversationFragment() :
             if (userIDs.isEmpty()) {
                 return
             }
-
-            val q = Query("user").contains("_id", userIDs.toList())
-            this.skygear?.publicDatabase?.query(q, object : RecordQueryResponseHandler() {
-                override fun onQueryError(error: Error?) {
+            this.skygearChat?.getParticipants(userIDs.toList(), object : GetParticipantsCallback {
+                override fun onGetCachedResult(participantsMap: MutableMap<String, Participant>?) {
+                    conversationView()?.updateAuthors(participantsMap?.values?.toList())
                 }
 
-                override fun onQuerySuccess(records: Array<out Record>?) {
-                    records?.let {
-                        conversationView()?.updateAuthors(records.toList())
-                        if (titleOption == ConversationTitleOption.OTHER_PARTICIPANTS) {
-                            this@ConversationFragment.activity.title = conversationView()?.getOtherParticipantsTitle()
-                        }
-                    }
+                override fun onFail(error: Error) {
+                }
+
+                override fun onSuccess(participantsMap: MutableMap<String, Participant>?) {
+                    conversationView()?.updateAuthors(participantsMap?.values?.toList())
                 }
             })
         }

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationView.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationView.kt
@@ -28,8 +28,8 @@ import io.skygear.chatkit.messages.VoiceMessageOnClickListener
 import io.skygear.chatkit.messages.MessageHolders
 import io.skygear.chatkit.messages.MessagesList
 import io.skygear.chatkit.messages.MessagesListAdapter
+import io.skygear.plugins.chat.Participant
 import io.skygear.skygear.Error
-import io.skygear.skygear.Record
 
 abstract class HoldingButtonLayoutBaseListener : HoldingButtonLayoutListener {
     override fun onBeforeCollapse() {}
@@ -473,19 +473,19 @@ open class ConversationView : RelativeLayout {
         }
     }
 
-    fun updateAuthors(authors: List<Record>) {
-        authors.forEach {
-            userMap[it.ownerId] = userBuilder.createUser(it)
+    fun updateAuthors(authors: List<Participant>?) {
+        authors?.forEach {
+            userMap[it.id] = userBuilder.createUser(it)
         }
         this.messageListAdapter?.updateMessagesAuthor(userMap)
     }
 
     open fun getOtherParticipantsTitle(): String {
         val names = userMap.values.filter {
-            it.chatUserId != this.skygear?.auth?.currentUser?.id
+            it.participantId != this.skygear?.auth?.currentUser?.id
         }.map {
             val key = it.displayNameField
-            it.chatUser?.record?.get(key) ?: it.chatUser?.record?.get(User.DefaultUsernameField)
+            it.participant?.record?.get(key) ?: it.participant?.record?.get(User.DefaultUsernameField)
         }
         return names?.joinToString(", ")
     }

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/User.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/User.kt
@@ -2,7 +2,7 @@ package io.skygear.plugins.chat.ui.model
 
 import io.skygear.chatkit.commons.models.IUser
 
-import io.skygear.plugins.chat.ChatUser
+import io.skygear.plugins.chat.Participant
 import io.skygear.plugins.chat.ui.AvatarType
 import io.skygear.plugins.chat.ui.utils.AvatarBuilder
 import io.skygear.skygear.Asset
@@ -15,13 +15,28 @@ class User : IUser {
         var DefaultAvatarField = "Unknown"
     }
 
-    val chatUser: ChatUser?
-    val chatUserId: String
+    val participant: Participant?
+    val participantId: String
     val avatarField: String?
     val displayNameField: String?
     var avatarType: AvatarType
     var avatarBackgroundColor: Int
     var avatarTextColor: Int
+
+    constructor(participant: Participant,
+                displayNameField: String?,
+                avatarField: String?,
+                avatarType: AvatarType,
+                avatarBackgroundColor: Int,
+                avatarInitialTextColor: Int) {
+        this.avatarField = avatarField
+        this.displayNameField = displayNameField
+        this.participant = participant
+        this.participantId = participant.id
+        this.avatarType = avatarType
+        this.avatarBackgroundColor = avatarBackgroundColor
+        this.avatarTextColor = avatarInitialTextColor
+    }
 
     constructor(record: Record,
                 displayNameField: String?,
@@ -31,8 +46,8 @@ class User : IUser {
                 avatarInitialTextColor: Int) {
         this.avatarField = avatarField
         this.displayNameField = displayNameField
-        this.chatUser = ChatUser.fromJson(record.toJson())
-        this.chatUserId = record.id
+        this.participant = Participant.fromJson(record.toJson())
+        this.participantId = record.id
         this.avatarType = avatarType
         this.avatarBackgroundColor = avatarBackgroundColor
         this.avatarTextColor = avatarInitialTextColor
@@ -46,32 +61,32 @@ class User : IUser {
                 avatarInitialTextColor: Int) {
         this.avatarField = avatarField
         this.displayNameField = displayNameField
-        this.chatUser = null
-        this.chatUserId = recordID
+        this.participant = null
+        this.participantId = recordID
         this.avatarType = avatarType
         this.avatarBackgroundColor = avatarBackgroundColor
         this.avatarTextColor = avatarInitialTextColor
     }
 
-    override fun getId() = this.chatUserId
+    override fun getId() = this.participantId
 
     override fun getName(): String {
-        if (this.chatUser == null) {
+        if (this.participant == null) {
             return DefaultDisplayName
         }
 
-        val userName = this.chatUser.record.get(this.displayNameField) as String?
+        val userName = this.participant.record.get(this.displayNameField) as String?
         return userName ?: User.DefaultDisplayName
     }
 
     override fun getAvatar(): String {
-        if (this.chatUser == null) {
+        if (this.participant == null) {
             return AvatarBuilder.avatarUriForName("", this.avatarBackgroundColor, this.avatarTextColor)
         }
 
         if (this.avatarType == AvatarType.IMAGE) {
             var avatarUrl: String? = null
-            val field = this.chatUser.record.get(this.avatarField)
+            val field = this.participant.record.get(this.avatarField)
 
             if (field is Asset) {
                 avatarUrl = field.url
@@ -86,7 +101,7 @@ class User : IUser {
             }
         }
 
-        val userName = this.chatUser.record.get(this.displayNameField) as String? ?: ""
+        val userName = this.participant.record.get(this.displayNameField) as String? ?: ""
         return AvatarBuilder.avatarUriForName(userName, this.avatarBackgroundColor, this.avatarTextColor)
     }
 }

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/UserBuilder.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/UserBuilder.kt
@@ -1,5 +1,6 @@
 package io.skygear.plugins.chat.ui.model
 
+import io.skygear.plugins.chat.Participant
 import io.skygear.plugins.chat.ui.AvatarType
 import io.skygear.skygear.Record
 
@@ -28,5 +29,9 @@ class UserBuilder {
 
     fun createUser(recordID: String): User {
         return User(recordID, displayNameField, avatarField, avatarType, avatarBackgroundColor, avatarTextColor)
+    }
+
+    fun createUser(participant: Participant): User {
+        return User(participant, displayNameField, avatarField, avatarType, avatarBackgroundColor, avatarTextColor)
     }
 }


### PR DESCRIPTION
Implement caching functionality in getParticipants API

- Remove getChatUsers
- Add getParticipants to ChatContainer
- Add ParticipantMigration
- Add GetParticipantssCallback
- Update UIKit
- Update chat_example code
- Add ParticipantCacheObject
- Add Unit Test
- rename ChatUser to Participant

Connects #153, #154, #155, #170, #171

Rename ChatUser to Participant