### PR TITLE
Image Message Orientation Bug Fix

### DIFF
--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
@@ -391,12 +391,12 @@ open class ConversationFragment() :
     /**
      * This function is for receiving new message and sending new message.
      */
-    private fun addMessageToBottom(message: ChatMessage, uri: Uri? = null) {
+    private fun addMessageToBottom(message: ChatMessage, uri: Uri? = null, orientation: Int? = null) {
         val view = conversationView()
         if (messageIDs.contains(message.id)) {
             view?.updateMessages(listOf(message))
         } else {
-            view?.addMessageToBottom(message, uri)
+            view?.addMessageToBottom(message, uri, orientation)
             messageIDs.add(message.id)
         }
 
@@ -836,7 +836,8 @@ open class ConversationFragment() :
     }
 
     fun sendImageMessage(imageUri: Uri) {
-        val imageData = getResizedBitmap(context, imageUri)
+        val orientation = getImageOrientation(context, imageUri)
+        val imageData = getResizedBitmap(context, imageUri, orientation)
         if (imageData == null) {
             Log.w(TAG, "Failed to decode image from uri: %s".format(imageUri))
             return
@@ -845,7 +846,7 @@ open class ConversationFragment() :
         this.conversation?.let { conv ->
             val imageMessage = MessageBuilder.createImageMessage(imageData)
             this.fragmentMessageSentListener?.onBeforeMessageSent(this, imageMessage)
-            this.addMessageToBottom(imageMessage, imageUri)
+            this.addMessageToBottom(imageMessage, imageUri, orientation)
             this.skygearChat?.addMessage(imageMessage, conv, object : SaveCallback<io.skygear.plugins.chat.Message> {
                 override fun onSuccess(message: ChatMessage?) {
                     callMessageSentSuccessListener(message)

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationView.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationView.kt
@@ -407,8 +407,8 @@ open class ConversationView : RelativeLayout {
         this.messageListAdapter?.merge(messages)
     }
 
-    open fun addMessageToBottom(message: ChatMessage, imageUri: Uri? = null) {
-        this.messageListAdapter?.addToStart(MessageFromChatMessage(message, imageUri), needToScrollToBottom())
+    open fun addMessageToBottom(message: ChatMessage, imageUri: Uri? = null, orientation: Int? = null) {
+        this.messageListAdapter?.addToStart(MessageFromChatMessage(message, imageUri, orientation), needToScrollToBottom())
     }
 
     open fun startListeningScroll() {
@@ -454,8 +454,8 @@ open class ConversationView : RelativeLayout {
         return multitypeMessages
     }
 
-    fun MessageFromChatMessage(chatMessage: ChatMessage, uri: Uri?): Message {
-        val multitypeMessage = MessageFactory.getMessage(chatMessage, getMessageStyle(), uri)
+    fun MessageFromChatMessage(chatMessage: ChatMessage, uri: Uri?, orientation: Int?): Message {
+        val multitypeMessage = MessageFactory.getMessage(chatMessage, getMessageStyle(), uri, orientation)
         updateMessageAuthor(multitypeMessage)
         return multitypeMessage
     }

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/ImageMessage.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/ImageMessage.kt
@@ -1,5 +1,6 @@
 package io.skygear.plugins.chat.ui.model
 
+import android.graphics.drawable.GradientDrawable
 import android.net.Uri
 import io.skygear.chatkit.commons.models.MessageContentType
 import org.json.JSONObject
@@ -14,15 +15,15 @@ class ImageMessage : Message,
 
     val chatMessageImageUrl: String?
 
-    constructor(m: ChatMessage, imageUri: Uri?, style: MessageStyle) : super(m, style) {
+    constructor(m: ChatMessage, imageUri: Uri?, orientation: Int?, style: MessageStyle) : super(m, style) {
         this.chatMessageImageUrl = this.imageUrlFromChatMessage(
                 this.chatMessage.asset?.url ?: imageUri?.toString(),
-                this.chatMessage.metadata)
+                this.chatMessage.metadata, orientation)
     }
 
     override fun getImageUrl(): String? = this.chatMessageImageUrl
 
-    fun imageUrlFromChatMessage(imageUrl: String?, meta: JSONObject?): String? {
+    fun imageUrlFromChatMessage(imageUrl: String?, meta: JSONObject?, orientation: Int?): String? {
         var url = imageUrl
         if (url == null) {
             return null
@@ -41,6 +42,10 @@ class ImageMessage : Message,
 
             if (it.has("height")) {
                 builder.appendQueryParameter("height", it.getInt("height").toString())
+            }
+
+            orientation?.let {
+                builder.appendQueryParameter("orientation", orientation.toString())
             }
 
             url = builder.build().toString()

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/MessageFactory.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/MessageFactory.kt
@@ -5,10 +5,10 @@ import android.net.Uri
 
 class MessageFactory {
     companion object {
-        fun getMessage(m: ChatMessage, style: MessageStyle, uri: Uri? = null): Message {
+        fun getMessage(m: ChatMessage, style: MessageStyle, uri: Uri? = null, orientation: Int? = null): Message {
             return m.asset?.mimeType.let {
                 when {
-                    it?.startsWith("image") == true -> ImageMessage(m, uri, style)
+                    it?.startsWith("image") == true -> ImageMessage(m, uri, orientation, style)
                     it?.equals(VoiceMessage.MIME_TYPE) == true -> VoiceMessage(m, style, uri)
                     else -> Message(m, style)
                 }

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/utils/ImageLoader.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/utils/ImageLoader.kt
@@ -1,13 +1,17 @@
 package io.skygear.plugins.chat.ui.utils
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.net.Uri
 import android.widget.ImageView
 import com.squareup.picasso.Picasso
 import io.skygear.chatkit.commons.ImageLoader
 import android.graphics.BitmapFactory
 import android.graphics.drawable.BitmapDrawable
+import android.media.ExifInterface
 import android.util.Base64
+import com.squareup.picasso.Transformation
+
 
 private val DISPLAY_IMAGE_SIZE = 500.0
 
@@ -48,7 +52,7 @@ class ImageLoader(
             }
             imageView?.layoutParams?.height = height.toInt()
             imageView?.layoutParams?.width = width.toInt()
-            creator.fit().centerCrop()
+            creator.fit().centerInside()
         }
 
         val imageDataBytes = builtUri.getQueryParameter("thumbnail")
@@ -58,6 +62,24 @@ class ImageLoader(
             if (bitmap != null) {
                 creator.placeholder(BitmapDrawable(this.context.resources, bitmap))
             }
+        }
+
+        var orientation = builtUri.getQueryParameter("orientation")?.toInt() ?: ExifInterface.ORIENTATION_NORMAL
+        var matrix = matrixFromRotation(orientation)
+
+        matrix?.let {
+            creator.transform(object: Transformation {
+                override fun key(): String {
+                    return "orientation"
+                }
+
+                override fun transform(source: Bitmap?): Bitmap {
+                    val bmRotated = Bitmap.createBitmap(source, 0, 0, source!!.width, source!!.height, matrix, true)
+                    source?.recycle()
+                    return bmRotated
+                }
+
+            })
         }
 
         creator.into(imageView)

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/utils/ImageUtils.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/utils/ImageUtils.kt
@@ -25,21 +25,8 @@ var mCurrentPhotoPath: String = ""
 data class ImageData(val thumbnail: Bitmap,
                      val image: Bitmap)
 
-fun getResizedBitmap(context: Context, uri: Uri): ImageData? {
-    var input = context.getContentResolver().openInputStream(uri)
-
-    val onlyBoundsOptions = BitmapFactory.Options()
-    onlyBoundsOptions.inJustDecodeBounds = true
-    onlyBoundsOptions.inPreferredConfig = Bitmap.Config.ARGB_8888//optional
-    BitmapFactory.decodeStream(input, null, onlyBoundsOptions)
-    input.close()
-
-    if (onlyBoundsOptions.outWidth == -1 || onlyBoundsOptions.outHeight == -1) {
-        return null
-    }
-
-    // get orientation exif
-    input = context.getContentResolver().openInputStream(uri)
+fun getImageOrientation(context: Context, uri: Uri): Int {
+    var input  = context.getContentResolver().openInputStream(uri)
     val file = File.createTempFile("image_tmp", ".jpg", context.getCacheDir())
     val fos = FileOutputStream(file)
 
@@ -56,7 +43,21 @@ fun getResizedBitmap(context: Context, uri: Uri): ImageData? {
     fos.close()
 
     val ef = ExifInterface(file.toString())
-    val orientation = ef.getAttributeInt(ExifInterface.TAG_ORIENTATION, 99)
+    return ef.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+}
+
+fun getResizedBitmap(context: Context, uri: Uri, orientation: Int): ImageData? {
+    var input = context.getContentResolver().openInputStream(uri)
+
+    val onlyBoundsOptions = BitmapFactory.Options()
+    onlyBoundsOptions.inJustDecodeBounds = true
+    onlyBoundsOptions.inPreferredConfig = Bitmap.Config.ARGB_8888//optional
+    BitmapFactory.decodeStream(input, null, onlyBoundsOptions)
+    input.close()
+
+    if (onlyBoundsOptions.outWidth == -1 || onlyBoundsOptions.outHeight == -1) {
+        return null
+    }
 
     val originalSize = if (onlyBoundsOptions.outHeight > onlyBoundsOptions.outWidth)
         onlyBoundsOptions.outHeight else onlyBoundsOptions.outWidth
@@ -91,11 +92,11 @@ fun bitmapToByteArray(bmp: Bitmap): ByteArray? {
     return stream.toByteArray()
 }
 
-fun rotateBitmap(bitmap: Bitmap, orientation: Int): Bitmap? {
+fun matrixFromRotation(orientation: Int): Matrix? {
     val matrix = Matrix()
     when (orientation) {
-        ExifInterface.ORIENTATION_NORMAL -> return bitmap
-        ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.setScale(-1f, 1f)
+        ExifInterface.ORIENTATION_NORMAL -> return null
+        ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix?.setScale(-1f, 1f)
         ExifInterface.ORIENTATION_ROTATE_180 -> matrix.setRotate(180f)
         ExifInterface.ORIENTATION_FLIP_VERTICAL -> {
             matrix.setRotate(180f)
@@ -111,11 +112,15 @@ fun rotateBitmap(bitmap: Bitmap, orientation: Int): Bitmap? {
             matrix.postScale(-1f, 1f)
         }
         ExifInterface.ORIENTATION_ROTATE_270 -> matrix.setRotate(-90f)
-        else -> return bitmap
+        else ->  return null
     }
+    return matrix
+}
+
+fun rotateBitmap(bitmap: Bitmap, orientation: Int): Bitmap? {
+    val matrix = matrixFromRotation(orientation)
     try {
         val bmRotated = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
-        bitmap.recycle()
         return bmRotated
     } catch (e: OutOfMemoryError) {
         e.printStackTrace()


### PR DESCRIPTION
- Cause: due to EXIF orientation not well supported in picasso
- Refactor matrixFromRotation in ImageUtils
- Support "orientation" key value in ImageLoader
- Pass orientation to ImageMessage in
  ConversationFragment.sendImageMessage
- Transform image to desired orientation in ImagePreviewActivity

Connects #161