### PR TITLE
Toast NPE bug fix

### DIFF
--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
@@ -99,7 +99,6 @@ open class ConversationFragment() :
     protected var connectionListener: ConnectionListener? = null
     protected var pubsubListener: PubsubListener? = null
 
-    @Override
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         updateTLSForKitKat(context)
@@ -126,6 +125,15 @@ open class ConversationFragment() :
         arguments.getSerializable(ConnectionListenerKey)?.let { listener ->
             connectionListener = listener as ConnectionListener
         }
+    }
+
+    override fun onDestroy() {
+        customAvatarAdapter = null
+        customViewAdapter = null
+        fragmentMessageFetchListener = null
+        fragmentMessageSentListener = null
+        connectionListener = null
+        super.onDestroy()
     }
 
     override fun onAttach(context: Context?) {


### PR DESCRIPTION
- Listeners are removed from ConversationFragment when the fragment is
  about to be destroyed.

Connects #172