### PR TITLE
Failed asset message handling

### DIFF
--- a/chat/src/main/java/io/skygear/plugins/chat/Message.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/Message.java
@@ -240,7 +240,14 @@ public class Message {
      * @throws JSONException the JSON exception
      */
     public static Message fromJson(JSONObject jsonObject) throws JSONException {
-        return new Message(Record.fromJson(jsonObject));
+        Record record = Record.fromJson(jsonObject);
+        Message message = new Message(record);
+
+        if (jsonObject.has("attachment")) {
+            JSONObject assetJson = jsonObject.getJSONObject("attachment");
+            message.setAsset(MessageAssetSerializer.deserialize(assetJson));
+        }
+        return message;
     }
 
     /**

--- a/chat/src/main/java/io/skygear/plugins/chat/MessageAssetCacheHelper.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/MessageAssetCacheHelper.java
@@ -1,0 +1,64 @@
+package io.skygear.plugins.chat;
+
+
+import android.content.Context;
+import android.os.AsyncTask;
+import android.util.Log;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+
+import io.skygear.skygear.Asset;
+import io.skygear.skygear.Error;
+
+public class MessageAssetCacheHelper {
+    private static final String TAG = "AssetCache";
+
+    static void saveMessageAsset(Context context, Message message) {
+        Asset asset = message.getAsset();
+        if (asset != null) {
+            File file = new File(context.getCacheDir(), message.getId());
+            try {
+                FileOutputStream fos = new FileOutputStream(file);
+                JSONObject object = MessageAssetSerializer.serialize(asset);
+                fos.write(object.toString().getBytes());
+                fos.close();
+            } catch (IOException e) {
+                Log.e(TAG, "Cannot save asset.", e);
+            }
+        }
+    }
+
+    public static Asset getAsset(Context context, String messageId) {
+        File file = new File(context.getCacheDir(), messageId);
+        Asset asset = null;
+        try {
+            if (file.exists()) {
+                FileInputStream ios = new FileInputStream(file);
+                int size = ios.available();
+                byte[] buffer = new byte[size];
+                ios.read(buffer);
+                String jsonString = new String(buffer, "UTF-8");
+                ios.close();
+                JSONObject object = new JSONObject(jsonString);
+                asset = MessageAssetSerializer.deserialize(object);
+            }
+        } catch (IOException e) {
+            Log.e(TAG, "Cannot delete asset.", e);
+        } catch (JSONException e) {
+            Log.e(TAG, "Cannot delete asset.", e);
+        }
+        return asset;
+    }
+
+    static void deleteMessageAsset(Context context, String messageId) {
+        File file = new File(context.getCacheDir(), messageId);
+        file.delete();
+    }
+}

--- a/chat/src/main/java/io/skygear/plugins/chat/MessageAssetSerializer.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/MessageAssetSerializer.java
@@ -1,0 +1,64 @@
+package io.skygear.plugins.chat;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import io.skygear.skygear.Asset;
+import android.util.Base64;
+
+/**
+ * AssetSerializer which serializes and de-serializes data field. For MessageOperationCacheObject only.
+ */
+
+public class MessageAssetSerializer {
+
+    /**
+     * Serialize an asset
+     *
+     * @param asset the asset
+     * @return the json object
+     */
+    public static JSONObject serialize(Asset asset) {
+        try {
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put("$type", "asset");
+            jsonObject.put("$name", asset.getName());
+            jsonObject.put("$content_type", asset.getMimeType());
+
+            if (asset.getUrl() != null) {
+                jsonObject.put("$url", asset.getUrl());
+            }
+
+            if (asset.getData() != null) {
+                jsonObject.put("data", Base64.encodeToString(asset.getData(), Base64.DEFAULT));
+            }
+
+            return jsonObject;
+        } catch (JSONException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Deserialize an asset from json object.
+     *
+     * @param assetJSONObject the asset json object
+     * @return the asset
+     * @throws JSONException the json exception
+     */
+    public static Asset deserialize(JSONObject assetJSONObject) throws JSONException {
+        String typeValue = assetJSONObject.getString("$type");
+        if (typeValue.equals("asset")) {
+            String assetName = assetJSONObject.getString("$name");
+            String assetMimeType = assetJSONObject.getString("$content_type");
+            if (assetJSONObject.has("data")) {
+                byte[] data = Base64.decode(assetJSONObject.getString("data"), Base64.DEFAULT);
+                return new Asset(assetName, assetMimeType, data);
+            }
+            String assetUrl = assetJSONObject.optString("$url", null);
+            return new Asset(assetName, assetUrl, assetMimeType);
+        }
+
+        throw new JSONException("Invalid $type value: " + typeValue);
+    }
+}

--- a/chat/src/main/java/io/skygear/plugins/chat/RealmStore.java
+++ b/chat/src/main/java/io/skygear/plugins/chat/RealmStore.java
@@ -112,6 +112,7 @@ class RealmStore {
                 message = cacheObject.toMessage();
                 messages.add(message);
             } catch (Exception e) {
+                Log.e(TAG, "Faulty Message Found: " + cacheObject.recordID, e);
                 faultyCacheObjects.add(cacheObject);
             }
         }
@@ -256,6 +257,7 @@ class RealmStore {
                 operation = cacheObject.toMessageOperation();
                 operations.add(operation);
             } catch (Exception e) {
+                Log.e(TAG, "Faulty Operation Found: " + cacheObject.operationID, e);
                 faultyCacheObjects.add(cacheObject);
             }
         }

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/holder/CustomMessageHolders.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/holder/CustomMessageHolders.kt
@@ -12,16 +12,30 @@ import io.skygear.plugins.chat.Conversation
 import io.skygear.plugins.chat.ui.AvatarAdapter
 import io.skygear.plugins.chat.ui.R
 import io.skygear.plugins.chat.ui.DefaultAvatarAdapter
+import io.skygear.plugins.chat.ui.model.ImageMessage
 import io.skygear.plugins.chat.ui.model.Message
 import io.skygear.plugins.chat.ui.model.VoiceMessage
 
 class CustomMessageHolders(avatarAdapterFunc: () -> AvatarAdapter, conversationFunc: () -> Conversation?) : MessageHolders() {
+    // Copied from chatkit project
+    val VIEW_TYPE_IMAGE_MESSAGE = 132
     var avatarAdapterFunc: () -> AvatarAdapter = { DefaultAvatarAdapter() }
     var voiceMessageOnClickListener: VoiceMessageOnClickListener? = null
     var conversationFunc: () -> Conversation? = { null }
     init {
         this.avatarAdapterFunc = avatarAdapterFunc
         this.conversationFunc = conversationFunc
+    }
+
+    override fun getViewType(item: Any, senderId: String): Int {
+        // getContentViewType from MessageHolders.java can only recognize ImageMessage with URL, however, failed ImageMessage does not have URL,
+        // since failed Image does not have a valid URL.
+        if (item is ImageMessage) {
+            val isOutcoming = item.user?.id?.contentEquals(senderId) ?: false
+            return (if (isOutcoming) -1 else 1) * VIEW_TYPE_IMAGE_MESSAGE
+        } else {
+            return super.getViewType(item, senderId)
+        }
     }
 
     /*

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/holder/OutgoingImageMessageView.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/holder/OutgoingImageMessageView.kt
@@ -1,22 +1,33 @@
 package io.skygear.plugins.chat.ui.holder
 
+import android.graphics.BitmapFactory
 import android.view.View
+import android.widget.ImageView
 import io.skygear.chatkit.messages.MessageHolders
+import io.skygear.plugins.chat.ui.R
 import io.skygear.plugins.chat.ui.model.ImageMessage
 
 class OutgoingImageMessageView(itemView: View) : MessageHolders.OutcomingImageMessageViewHolder<ImageMessage>(itemView) {
     var receiverAvatarMessageView: ReceiverAvatarMessageView? = null
     var usernameMessageView: UsernameMessageView? = null
     var timeMessageView: OutgoingTimeMessageView? = null
+    var imageView: ImageView? = null
 
     init {
         receiverAvatarMessageView = ReceiverAvatarMessageView(itemView)
         usernameMessageView = UsernameMessageView(itemView)
         timeMessageView = OutgoingTimeMessageView(itemView)
+        imageView = itemView.findViewById(R.id.image)
     }
 
     override fun onBind(message: ImageMessage) {
         super.onBind(message)
+        if (message.chatMessage.asset != null && message.imageUrl == null) {
+            message.chatMessage.asset?.data?.let { data ->
+                val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size)
+                imageView?.setImageBitmap(bitmap)
+            }
+        }
         usernameMessageView?.onBind(message)
         receiverAvatarMessageView?.onBind(message)
         timeMessageView?.onBind(message)

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/VoiceMessage.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/VoiceMessage.kt
@@ -41,7 +41,7 @@ open class VoiceMessage : Message, MessageContentType {
         get() = this.chatMessage.record.get(VoiceMessage.AttachmentFieldName) as Asset
 
     val attachmentUrl
-        get() = this.uri?.toString() ?: this.attachment.url as String
+        get() = this.uri?.toString() ?: this.attachment.url
 
     val duration
         get() = this.chatMessage.metadata!!.getInt(VoiceMessage.DurationMatadataName)

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/utils/VoiceMessagePlayer.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/utils/VoiceMessagePlayer.kt
@@ -17,6 +17,8 @@ class VoiceMessagePlayer(val context: Context) {
 
     fun play() {
         this.message?.let { msg ->
+            val url = msg.attachmentUrl ?: return
+
             if (msg.state == VoiceMessage.State.PAUSED) {
                 this.mediaPlayer?.start()
                 msg.state = VoiceMessage.State.PLAYING
@@ -26,7 +28,9 @@ class VoiceMessagePlayer(val context: Context) {
             }
 
             this.mediaPlayer = MediaPlayer()
-            this.mediaPlayer?.setDataSource(msg.attachmentUrl)
+
+            this.mediaPlayer?.setDataSource(url)
+
             this.mediaPlayer?.setOnCompletionListener {
                 msg.state = VoiceMessage.State.INITIAL
                 this.messageStateChangeListener?.onVoiceMessageStateChanged(msg)


### PR DESCRIPTION
- Force Close Bug Fix
- Add MessageAssetCacheHelper to support persistent asset in android
  disk cache
- Add MessageAssetSerializer to support deserialization of pending asset
- Update RealmStore
- Update OutgoingImageMessageView.onBind to display un-uploaded asset
- Voice Message and VoiceMessagePlayer Bug Fix

Connects #181