### PR TITLE
Fix fail to load image when clicking preview

### DIFF
--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/ConversationFragment.kt
@@ -796,7 +796,7 @@ open class ConversationFragment() :
         message?.let { msg ->
             when (msg) {
                 is ImageMessage -> {
-                    msg.imageUrl
+                    msg.chatMessageImageUrl
                             ?.let { url -> ImagePreviewActivity.newIntent(activity, url) }
                             ?.let { intent -> this@ConversationFragment.startActivity(intent) }
                 }

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/holder/IncomingImageMessageView.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/holder/IncomingImageMessageView.kt
@@ -3,6 +3,7 @@ package io.skygear.plugins.chat.ui.holder
 import android.view.View
 import io.skygear.chatkit.messages.MessageHolders
 import io.skygear.plugins.chat.ui.model.ImageMessage
+import io.skygear.plugins.chat.ui.utils.ImageLoader
 
 class IncomingImageMessageView(itemView: View) : MessageHolders.IncomingImageMessageViewHolder<ImageMessage>(itemView) {
 
@@ -17,6 +18,12 @@ class IncomingImageMessageView(itemView: View) : MessageHolders.IncomingImageMes
 
     override fun onBind(message: ImageMessage) {
         super.onBind(message)
+        val loader = imageLoader
+        if (loader is ImageLoader && image != null) {
+            loader.loadImage(image, message.chatMessageImageUrl, message.thumbnail,
+                    message.width, message.height, message.orientation)
+        }
+
         usernameMessageView?.onBind(message)
         timeMessageView?.onBind(message)
         senderAvatarMessageView?.onBind(message)

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/holder/OutgoingImageMessageView.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/holder/OutgoingImageMessageView.kt
@@ -6,6 +6,7 @@ import android.widget.ImageView
 import io.skygear.chatkit.messages.MessageHolders
 import io.skygear.plugins.chat.ui.R
 import io.skygear.plugins.chat.ui.model.ImageMessage
+import io.skygear.plugins.chat.ui.utils.ImageLoader
 
 class OutgoingImageMessageView(itemView: View) : MessageHolders.OutcomingImageMessageViewHolder<ImageMessage>(itemView) {
     var receiverAvatarMessageView: ReceiverAvatarMessageView? = null
@@ -22,7 +23,12 @@ class OutgoingImageMessageView(itemView: View) : MessageHolders.OutcomingImageMe
 
     override fun onBind(message: ImageMessage) {
         super.onBind(message)
-        if (message.chatMessage.asset != null && message.imageUrl == null) {
+        val loader = imageLoader
+        if (loader is ImageLoader && image != null && message.chatMessageImageUrl != null) {
+            loader.loadImage(image, message.chatMessageImageUrl, message.thumbnail,
+                    message.width, message.height, message.orientation)
+        }
+        if (message.chatMessage.asset != null && message.chatMessageImageUrl == null) {
             message.chatMessage.asset?.data?.let { data ->
                 val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size)
                 imageView?.setImageBitmap(bitmap)

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/ImageMessage.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/model/ImageMessage.kt
@@ -2,7 +2,6 @@ package io.skygear.plugins.chat.ui.model
 
 import android.net.Uri
 import io.skygear.chatkit.commons.models.MessageContentType
-import org.json.JSONObject
 import io.skygear.plugins.chat.Message as ChatMessage
 
 /**
@@ -13,42 +12,32 @@ class ImageMessage : Message,
         MessageContentType.Image {
 
     val chatMessageImageUrl: String?
+    var thumbnail: String? = null
+    var width: Int? = null
+    var height: Int? = null
+    var orientation: Int? = null
 
     constructor(m: ChatMessage, imageUri: Uri?, orientation: Int?, style: MessageStyle) : super(m, style) {
-        this.chatMessageImageUrl = this.imageUrlFromChatMessage(
-                this.chatMessage.asset?.url ?: imageUri?.toString(),
-                this.chatMessage.metadata, orientation)
-    }
-
-    override fun getImageUrl(): String? = this.chatMessageImageUrl
-
-    fun imageUrlFromChatMessage(imageUrl: String?, meta: JSONObject?, orientation: Int?): String? {
-        var url = imageUrl
-        if (url == null) {
-            return null
-        }
-        meta?.let {
-            val builder = Uri.parse(url)
-                    .buildUpon()
-
+        this.chatMessageImageUrl = this.chatMessage.asset?.url ?: imageUri?.toString()
+        this.chatMessage.metadata?.let {
             if (it.has("thumbnail")) {
-                builder.appendQueryParameter("thumbnail", it.getString("thumbnail"))
+                this.thumbnail = it.getString("thumbnail")
             }
 
             if (it.has("width")) {
-                builder.appendQueryParameter("width", it.getInt("width").toString())
+                this.width = it.getInt("width")
             }
 
             if (it.has("height")) {
-                builder.appendQueryParameter("height", it.getInt("height").toString())
+                this.height = it.getInt("height")
             }
-
-            orientation?.let {
-                builder.appendQueryParameter("orientation", orientation.toString())
-            }
-
-            url = builder.build().toString()
         }
-        return url
+
+        this.orientation = orientation
     }
+
+    // Return null for image url to skip the default image loading of chatkit
+    // Customized the image loading with base64 thumbnail
+    // see onBind of IncomingImageMessageView.kt
+    override fun getImageUrl(): String? = null
 }

--- a/chat_ui/src/main/java/io/skygear/plugins/chat/ui/utils/ImageLoader.kt
+++ b/chat_ui/src/main/java/io/skygear/plugins/chat/ui/utils/ImageLoader.kt
@@ -2,7 +2,6 @@ package io.skygear.plugins.chat.ui.utils
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.net.Uri
 import android.widget.ImageView
 import com.squareup.picasso.Picasso
 import io.skygear.chatkit.commons.ImageLoader
@@ -31,30 +30,35 @@ class ImageLoader(
             return
         }
 
+        var creator = Picasso.with(this.context)
+                .load(url)
+        creator.into(imageView)
+    }
+
+    fun loadImage(imageView: ImageView?, url: String?, thumbnail: String?, width: Int?, height: Int?, orientation: Int?) {
         // Load chat image message
         var creator = Picasso.with(this.context)
                 .load(url)
 
-        val builtUri = Uri.parse(url)
-        var height = builtUri.getQueryParameter("height")?.toDouble() ?: 0.0
-        var width = builtUri.getQueryParameter("width")?.toDouble() ?: 0.0
-        if (0 < height && 0 < width) {
-            if (height > DISPLAY_IMAGE_SIZE || width > DISPLAY_IMAGE_SIZE) {
-                var ratio = height / width
+        var h = height?.toDouble() ?: 0.0
+        var w = width?.toDouble() ?: 0.0
+        if (0 < h && 0 < w) {
+            if (h > DISPLAY_IMAGE_SIZE || w > DISPLAY_IMAGE_SIZE) {
+                var ratio = h / w
                 if (ratio > 1) {
-                    height = DISPLAY_IMAGE_SIZE
-                    width = DISPLAY_IMAGE_SIZE / ratio
+                    h = DISPLAY_IMAGE_SIZE
+                    w = DISPLAY_IMAGE_SIZE / ratio
                 } else {
-                    height = DISPLAY_IMAGE_SIZE * ratio
-                    width = DISPLAY_IMAGE_SIZE
+                    h = DISPLAY_IMAGE_SIZE * ratio
+                    w = DISPLAY_IMAGE_SIZE
                 }
             }
-            imageView?.layoutParams?.height = height.toInt()
-            imageView?.layoutParams?.width = width.toInt()
+            imageView?.layoutParams?.height = h.toInt()
+            imageView?.layoutParams?.width = w.toInt()
             creator.fit().centerInside()
         }
 
-        val imageDataBytes = builtUri.getQueryParameter("thumbnail")
+        val imageDataBytes = thumbnail
         if (imageDataBytes != null) {
             val bytes = Base64.decode(imageDataBytes.toByteArray(), Base64.DEFAULT)
             val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
@@ -63,8 +67,8 @@ class ImageLoader(
             }
         }
 
-        var orientation = builtUri.getQueryParameter("orientation")?.toInt() ?: ExifInterface.ORIENTATION_NORMAL
-        var matrix = matrixFromRotation(orientation)
+        var o = orientation ?: ExifInterface.ORIENTATION_NORMAL
+        var matrix = matrixFromRotation(o)
 
         matrix?.let {
             creator.transform(object : Transformation {


### PR DESCRIPTION
connect #215 
connects oursky/skygear-support#66

The original implementation embedded the meta data (height, width,
thumbnail..etc) to url query params for chatkit to load the thumbnail
in chat view. This changed the image url and caused `SignatureDoesNotMatch`
when using s3 asset provider. This fix override the onBind of
ImageMessageView to use another load image function of image loader, so
that we don't need to alter the url.